### PR TITLE
Floating overlay toolbar

### DIFF
--- a/taplt/ui/main_window.py
+++ b/taplt/ui/main_window.py
@@ -64,6 +64,7 @@ class LabelingMainWindow(QMainWindow):
 
         self.welcome_screen = WelcomeScreen()
         self.file_display = CenterDisplayWidget()
+        self.file_display.hide_button.setVisible(False)
 
         # default widget when no images exist in the project
         self.no_files = QLabel()
@@ -114,22 +115,16 @@ class LabelingMainWindow(QMainWindow):
         self.statusbar = QStatusBar()
         self.setStatusBar(self.statusbar)
 
-        #self.toolBar = Toolbar(self)
-        #self.addToolBar(Qt.ToolBarArea.LeftToolBarArea, self.toolBar)
-        #self.toolBar.init_margins()
-
-        # Attach the toolbar to the canvas as an overlay
         self.toolBar = Toolbar(self.center_frame)
         self.toolBar.show()
         self.toolBar.raise_()
-        self.position_toolbar()
 
         # Toolbar setup actions for images, videos and whole slides
         self.toolBar.init_actions('image', self.define_img_actions())
         self.toolBar.init_actions('slide', self.define_wsi_actions())
         self.toolBar.init_actions('video', self.define_video_actions())
         self.file_display.modalitySwitched.connect(self.toolBar.switch_modality)
-
+        
         # Show tooltip while drawing
         self.file_display.sDrawingTooltip.connect(self.set_tool_tip)
 
@@ -238,13 +233,21 @@ class LabelingMainWindow(QMainWindow):
     def hide_toolbar(self):
         """Legacy hook: Toolbar toggling is now handled inside the Toolbar itself."""
         self.toolBar.toggle_button.click()
-        #"""hides or shows the toolbar"""
-        #if self.toolBar.isHidden():
-            #self.toolBar.setHidden(False)
-            #self.file_display.hide_button.setIcon(get_icon("prev"))
-        #else:
-            #self.toolBar.setHidden(True)
-            #self.file_display.hide_button.setIcon(get_icon("next"))
+
+    def _position_toolbar(self):
+        """Position the toolbar overlay at the left side, vertically centered."""
+        if not hasattr(self, "toolBar") or self.toolBar is None:
+            return
+
+        margin = 12
+        x = margin
+        y = max(margin, (self.center_frame.height() - self.toolBar.height()) // 2)
+        self.toolBar.move(x, y)
+        self.toolBar.raise_()
+
+    def resizeEvent(self, event):
+        super(LabelingMainWindow, self).resizeEvent(event)
+        self._position_toolbar()
 
     def import_file(self, existing_patients: list):
         """executes a dialog to let the user enter all information regarding file import"""
@@ -351,6 +354,9 @@ class LabelingMainWindow(QMainWindow):
             self.polygons.update_polygons(current_labels)
         else:
             self.set_no_files_screen(True)
+
+        self.toolBar.adjustSize()
+        self._position_toolbar()
 
     def define_img_actions(self):
         actions = (Action(self,
@@ -481,22 +487,3 @@ class LabelingMainWindow(QMainWindow):
                    )
         actions = list(actions)
         return actions
-    
-    def position_toolbar(self):
-        """Positions the toolbar as an overlay on the center frame"""
-        
-        toolbar_size = self.toolBar.sizeHint()
-        canvas = self.center_frame
-
-        margin = 12 # Distance from the left edge of the canvas
-        
-        x = margin
-        y = (canvas.height() - toolbar_size.height()) // 2
-        
-        self.toolBar.move(int(x), int(y))
-        self.toolBar.raise_()
-
-    def resizeEvent(self, event):
-        """Repositions the toolbar when the window is resized"""
-        super().resizeEvent(event)
-        self.position_toolbar()

--- a/taplt/ui/main_window.py
+++ b/taplt/ui/main_window.py
@@ -114,9 +114,15 @@ class LabelingMainWindow(QMainWindow):
         self.statusbar = QStatusBar()
         self.setStatusBar(self.statusbar)
 
-        self.toolBar = Toolbar(self)
-        self.addToolBar(Qt.ToolBarArea.LeftToolBarArea, self.toolBar)
-        self.toolBar.init_margins()
+        #self.toolBar = Toolbar(self)
+        #self.addToolBar(Qt.ToolBarArea.LeftToolBarArea, self.toolBar)
+        #self.toolBar.init_margins()
+
+        # Attach the toolbar to the canvas as an overlay
+        self.toolBar = Toolbar(self.center_frame)
+        self.toolBar.show()
+        self.toolBar.raise_()
+        self.position_toolbar()
 
         # Toolbar setup actions for images, videos and whole slides
         self.toolBar.init_actions('image', self.define_img_actions())
@@ -230,13 +236,15 @@ class LabelingMainWindow(QMainWindow):
             self.sRequestUpdate.emit(new_img_idx)
 
     def hide_toolbar(self):
-        """hides or shows the toolbar"""
-        if self.toolBar.isHidden():
-            self.toolBar.setHidden(False)
-            self.file_display.hide_button.setIcon(get_icon("prev"))
-        else:
-            self.toolBar.setHidden(True)
-            self.file_display.hide_button.setIcon(get_icon("next"))
+        """Legacy hook: Toolbar toggling is now handled inside the Toolbar itself."""
+        self.toolBar.toggle_button.click()
+        #"""hides or shows the toolbar"""
+        #if self.toolBar.isHidden():
+            #self.toolBar.setHidden(False)
+            #self.file_display.hide_button.setIcon(get_icon("prev"))
+        #else:
+            #self.toolBar.setHidden(True)
+            #self.file_display.hide_button.setIcon(get_icon("next"))
 
     def import_file(self, existing_patients: list):
         """executes a dialog to let the user enter all information regarding file import"""
@@ -473,3 +481,22 @@ class LabelingMainWindow(QMainWindow):
                    )
         actions = list(actions)
         return actions
+    
+    def position_toolbar(self):
+        """Positions the toolbar as an overlay on the center frame"""
+        
+        toolbar_size = self.toolBar.sizeHint()
+        canvas = self.center_frame
+
+        margin = 12 # Distance from the left edge of the canvas
+        
+        x = margin
+        y = (canvas.height() - toolbar_size.height()) // 2
+        
+        self.toolBar.move(int(x), int(y))
+        self.toolBar.raise_()
+
+    def resizeEvent(self, event):
+        """Repositions the toolbar when the window is resized"""
+        super().resizeEvent(event)
+        self.position_toolbar()

--- a/taplt/ui/toolbar.py
+++ b/taplt/ui/toolbar.py
@@ -21,7 +21,8 @@ class Toolbar(QToolBar):
         self.setAutoFillBackground(False)
         self.setStyleSheet("background-color: rgb(186, 189, 182);")
         self.setMovable(False)
-        self.setAllowedAreas(Qt.ToolBarArea.LeftToolBarArea)
+        self.setFloatable(False)
+        self.setAllowedAreas(Qt.ToolBarArea.NoToolBarArea) 
         self.setOrientation(Qt.Orientation.Vertical)
         self.setLayoutDirection(Qt.LayoutDirection.LeftToRight)
         self.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextUnderIcon)
@@ -32,6 +33,14 @@ class Toolbar(QToolBar):
         self.button_group.buttonToggled.connect(self.exclusive_optional)
         self.modality_dict = {}
         self.current_modality = ""
+
+        self.toggle_button = QToolButton()
+        self.toggle_button.setText("⟨")
+        self.toggle_button.setCheckable(True)
+        self.toggle_button.setChecked(True)
+        self.toggle_button.clicked.connect(self._toggle_visibility)
+
+        self.addWidget(self.toggle_button)
 
     def disable_drawing(self, disable: bool):
         [btn.setDisabled(disable) for btn in self.button_group.buttons()]
@@ -114,7 +123,10 @@ class Toolbar(QToolBar):
                 RuntimeError("The modality does not exist/was not initialized yet.")
 
             self.current_modality = modality_name
-            self.addActions(self.modality_dict[modality_name])
+            self.addActions(self.modality_dict[modality_name])  
+
+            self.adjustSize()
+            self.setMinimumHeight(self.sizeHint().height())
 
     def clear_actions(self):
         """
@@ -126,3 +138,10 @@ class Toolbar(QToolBar):
             button.deleteLater()
 
         self.actionsDict.clear()
+    
+    def _toggle_visibility(self, checked: bool):
+        for w in self.findChildren(QToolButton):
+            if w is not self.toggle_button:
+                w.setVisible(checked)
+
+        self.toggle_button.setText("⟨" if checked else "⟩")

--- a/taplt/ui/toolbar.py
+++ b/taplt/ui/toolbar.py
@@ -6,7 +6,7 @@ from typing import *
 from taplt.src.actions import Action
 
 
-class Toolbar(QToolBar):
+class Toolbar(QWidget):
 
     sCreateNewProject = Signal(str, dict)
     sOpenProject = Signal(str)
@@ -14,19 +14,18 @@ class Toolbar(QToolBar):
 
     def __init__(self, parent):
         super(Toolbar, self).__init__(parent)
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(4)
+
+        self.setLayout(layout)
+        self.setFixedWidth(80)
+        self.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+
         self.actionsDict = {}  # This is a lookup table to match the buttons to the numbers they got added
 
-        self.setMinimumSize(QSize(80, 100))
-        self.setMaximumSize(QSize(80, 16777215))
         self.setAutoFillBackground(False)
         self.setStyleSheet("background-color: rgb(186, 189, 182);")
-        self.setMovable(False)
-        self.setFloatable(False)
-        self.setAllowedAreas(Qt.ToolBarArea.NoToolBarArea) 
-        self.setOrientation(Qt.Orientation.Vertical)
-        self.setLayoutDirection(Qt.LayoutDirection.LeftToRight)
-        self.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextUnderIcon)
-        self.setContextMenuPolicy(Qt.ContextMenuPolicy.DefaultContextMenu)
         self.setObjectName("toolBar")
         self.button_group = QButtonGroup()
         self.button_group.setExclusive(True)
@@ -40,7 +39,10 @@ class Toolbar(QToolBar):
         self.toggle_button.setChecked(True)
         self.toggle_button.clicked.connect(self._toggle_visibility)
 
-        self.addWidget(self.toggle_button)
+        self.layout().addWidget(self.toggle_button)
+
+        self._expanded_height = None
+        self.adjustSize()
 
     def disable_drawing(self, disable: bool):
         [btn.setDisabled(disable) for btn in self.button_group.buttons()]
@@ -50,21 +52,21 @@ class Toolbar(QToolBar):
 
     def addAction(self, action: Action):
         r"""Because I want a physical button in the toolbar, i need to create a widget"""
-        if isinstance(action, QWidgetAction):
-            return super(Toolbar, self).addAction(action)
+        """if isinstance(action, QWidgetAction):
+            return super(Toolbar, self).addAction(action)"""
         btn = QToolButton()
         # btn.setAutoRaise(True)
         btn.setCheckable(action.isCheckable())
         if action.isCheckable():
             self.button_group.addButton(btn)
         btn.setDefaultAction(action)
-        btn.setToolButtonStyle(self.toolButtonStyle())
+        btn.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextUnderIcon)
         btn.setMinimumSize(80, 70)
         btn.setMaximumSize(80, 70)
-        self.addWidget(btn)
+        self.layout().addWidget(btn)
 
-        action_text = action.text().replace('\n', '')
-        self.actionsDict[action_text] = len(self.actionsDict)
+        """action_text = action.text().replace('\n', '')
+        self.actionsDict[action_text] = len(self.actionsDict)"""
 
     def addActions(self, actions: Iterable[Action]) -> None:
         for action in actions:
@@ -75,7 +77,7 @@ class Toolbar(QToolBar):
 
     def contextMenuEvent(self, event) -> None:
         if "DrawPolygon" in self.actionsDict:
-            if self.actionGeometry(self.actions()[self.actionsDict["DrawPolygon"]]).contains(event.pos()):
+            if self.layout().itemAt(self.actionsDict["DrawPolygon"]).widget().geometry().contains(event.pos()):
                 # TODO: raise own context menu with options for drawing a circle or a rectangle
                 pass
 
@@ -89,22 +91,29 @@ class Toolbar(QToolBar):
             raise AttributeError(f"Action '{action_str}' not available. Available actions are"
                                  f"\n{[act for act in self.actionsDict.keys()]}")
         else:
-            return self.widgetForAction(self.actions()[self.actionsDict[action_str]]).defaultAction()
+            return self.layout().itemAt(self.actionsDict[action_str]).widget().defaultAction()
 
     def get_widget_for_action(self, action_str: str):
         if action_str not in self.actionsDict:
             raise AttributeError(f"Action '{action_str}' not available. Available actions are"
                                  f"\n{[act for act in self.actionsDict.keys()]}")
         else:
-            return self.widgetForAction(self.actions()[self.actionsDict[action_str]])
+            return self.layout().itemAt(self.actionsDict[action_str]).widget()
 
     def init_margins(self):
-        """This function is necessary because the call to addToolBar in label_ui.py alters the alignment
-        for some reason. Therefore, this method will be called AFTER the toolbar is added to the main window"""
-        m = (0, 0, 0, 0)
-        self.setContentsMargins(*m)
-        self.layout().setSpacing(2)
-        self.layout().setContentsMargins(*m)
+        """No-op for overlay toolbar. Positioning is handled by the parent widget."""
+        pass
+
+    def set_overlay_position(self, parent_widget: QWidget, margin: int = 10):
+        """Position the toolbar as an overlay on the given parent widget."""
+        if parent_widget is None:
+            return
+
+        parent_rect = parent_widget.rect()
+        x = margin
+        y = max(margin, (parent_rect.height() - self.height()) // 2)
+        self.move(x, y)
+        self.raise_()
 
     def switch_modality(self, modality_name: str):
         """
@@ -126,7 +135,10 @@ class Toolbar(QToolBar):
             self.addActions(self.modality_dict[modality_name])  
 
             self.adjustSize()
-            self.setMinimumHeight(self.sizeHint().height())
+            
+            parent = self.parentWidget()
+            if parent and hasattr(parent, "position_toolbar"):
+                parent._position_toolbar()
 
     def clear_actions(self):
         """
@@ -140,8 +152,18 @@ class Toolbar(QToolBar):
         self.actionsDict.clear()
     
     def _toggle_visibility(self, checked: bool):
-        for w in self.findChildren(QToolButton):
-            if w is not self.toggle_button:
+        # Show/hide all tool buttons except the toggle itself
+        for i in range(1, self.layout().count()):
+            w = self.layout().itemAt(i).widget()
+            if w:
                 w.setVisible(checked)
 
+        # Adjust arrow direction
         self.toggle_button.setText("⟨" if checked else "⟩")
+
+        self.adjustSize()
+
+        parent = self.parentWidget()
+        if parent and hasattr(parent, "position_toolbar"):
+            parent._position_toolbar()
+        

--- a/test/testing.py
+++ b/test/testing.py
@@ -160,11 +160,21 @@ def test_tab():
 
 def test_toolbar():
     window = QMainWindow()
-    window.setFixedSize(150, 800)
-    tb = Toolbar(window)
-    window.addToolBar(Qt.ToolBarArea.LeftToolBarArea, tb)
-    tb.init_margins()
-    tb.init_actions(window)
+    window.resize(400, 800)
+
+    center = QWidget()
+    center.setLayout(QVBoxLayout())
+    window.setCentralWidget(center)
+
+    tb = Toolbar(center)
+
+    mw = LabelingMainWindow()
+    tb.init_actions("image", mw.define_img_actions())
+    tb.switch_modality("image")
+
+    tb.move(10, 10)
+    tb.show()
+    
     window.show()
     app.exec()
 
@@ -189,5 +199,5 @@ if __name__ == "__main__":
     test_tree_widget()
     # test_dialog_new_label()
     # test_image_display()
-    # test_toolbar()
+    test_toolbar()
     # test_main_window()


### PR DESCRIPTION
Resolves #8 

Die Toolbar wurde von einer fest angedockten QToolBar zu einer frei positionierten Overlay-Toolbar umgebaut.

Sie ist jetzt links mit Abstand, vertikal zur Canvas positioniert und schwebt über dem Bild. Die Toolbar bleibt weiterhin ein- und ausklappbar.

### **Änderungen**

`toolbar.py`

- Umstellung der Toolbar von QToolBar auf QWidget, um freie Positionierung zu ermöglichen
- Entfernen der Docking-Eigenschaften
-  `_toggle_visibility`: Ein- und Ausklappen der Toolbar
- `set_overlay_position()`: Toolbar als Overlay auf dem Parent Widget erstellen
- Anpassung weiterer Funktionen:
  - `addAction()`
  - `init_margins()`
  - `switch_modality()`

`main_window.py`

- Overlay‑Einbindung über Parent‑Widget
- `_position_toolbar()`: Keine feste Dock‑Position mehr, stattdessen Overlay‑Positionierung
- Anpassungen in `hide_toolbar()`, `resizeEvent()` und contextMenuEvent()

`testing.py`
- `test_toolbar()`: ist für QWidget angepasst und manueller GUI‑Test ergänzt

### **Vorher:**

Fest angedockte Toolbar am linken Fensterrand

![Vorher](https://github.com/user-attachments/assets/e5c89d0d-a1f3-42fd-9f27-758cd744a3eb)


### **Nachher:**

Schwebende Overlay‑Toolbar mit Abstand und vertikaler Zentrierung

![Nachher](https://github.com/user-attachments/assets/cee2be6f-8f34-4f15-8e89-9cee06ad960b)
