### PR TITLE
add zoom level widget

### DIFF
--- a/taplt/media_viewing_widgets/widgets/image_viewer.py
+++ b/taplt/media_viewing_widgets/widgets/image_viewer.py
@@ -15,6 +15,7 @@ class ImageViewer(QGraphicsView):
         self.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
         self.setViewportUpdateMode(QGraphicsView.ViewportUpdateMode.FullViewportUpdate)
         self.setMouseTracking(True)
+        self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
 
         # Protected Item
         self._scaling_factor = 5 / 4
@@ -31,6 +32,7 @@ class ImageViewer(QGraphicsView):
                 factor = min(view_rect.width() / scene_rect.width(),
                              view_rect.height() / scene_rect.height())
                 self.scale(factor, factor)
+                self._emit_zoom()
 
     def resizeEvent(self, event: QResizeEvent) -> None:
         bounds = self.scene().itemsBoundingRect()
@@ -42,6 +44,7 @@ class ImageViewer(QGraphicsView):
             if self._enableZoomPan:
                 factor = self._scaling_factor if event.angleDelta().y() > 0 else 1/self._scaling_factor
                 self.scale(factor, factor)
+            self._emit_zoom()
 
     def keyPressEvent(self, event) -> None:
         if not self.b_isEmpty:
@@ -58,3 +61,9 @@ class ImageViewer(QGraphicsView):
             if event.key() == Qt.Key.Key_Control:
                 self._enableZoomPan = False
                 self.setDragMode(QGraphicsView.DragMode.NoDrag)
+
+    def _emit_zoom(self):
+        current_zoom = float(self.transform().m11())
+        parent = self.parentWidget()
+        if hasattr(parent, "sZoomChanged"):
+            parent.sZoomChanged.emit(current_zoom)

--- a/taplt/ui/file_display.py
+++ b/taplt/ui/file_display.py
@@ -21,6 +21,8 @@ class CenterDisplayWidget(QWidget):
     sChangeFile = Signal(int)
     sDrawingTooltip = Signal(str)
     modalitySwitched = Signal(str)
+    sZoomChanged = Signal(float)
+
     CREATE, EDIT = 0, 1
 
     def __init__(self, *args):
@@ -103,6 +105,7 @@ class CenterDisplayWidget(QWidget):
         self.hide_button.raise_()
 
         self.switch_to_modality(filepath)
+        self.sZoomChanged.emit(1.0)
         self.patient_label.setText(patient)
         return labels
 

--- a/taplt/ui/file_display.py
+++ b/taplt/ui/file_display.py
@@ -105,7 +105,7 @@ class CenterDisplayWidget(QWidget):
         self.hide_button.raise_()
 
         self.switch_to_modality(filepath)
-        self.sZoomChanged.emit(1.0)
+        # self.sZoomChanged.emit(1.0)
         self.patient_label.setText(patient)
         return labels
 

--- a/taplt/ui/image_viewer.py
+++ b/taplt/ui/image_viewer.py
@@ -42,6 +42,11 @@ class ImageViewer(QGraphicsView):
             if self._enableZoomPan:
                 factor = self._scaling_factor if event.angleDelta().y() > 0 else 1/self._scaling_factor
                 self.scale(factor, factor)
+                # calculate zoom factor + send to CenterDisplayWidget
+                current_zoom = float(self.transform().m11())
+                parent = self.parentWidget()
+                if hasattr(parent, "sZoomChanged"):
+                    parent.sZoomChanged.emit(current_zoom)
 
     def keyPressEvent(self, event) -> None:
         if not self.b_isEmpty:

--- a/taplt/ui/image_viewer.py
+++ b/taplt/ui/image_viewer.py
@@ -15,6 +15,7 @@ class ImageViewer(QGraphicsView):
         self.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
         self.setViewportUpdateMode(QGraphicsView.ViewportUpdateMode.FullViewportUpdate)
         self.setMouseTracking(True)
+        self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
 
         # Protected Item
         self._scaling_factor = 5 / 4
@@ -43,7 +44,7 @@ class ImageViewer(QGraphicsView):
             if self._enableZoomPan:
                 factor = self._scaling_factor if event.angleDelta().y() > 0 else 1/self._scaling_factor
                 self.scale(factor, factor)
-                self._emit_zoom()
+            self._emit_zoom()
 
     def keyPressEvent(self, event) -> None:
         if not self.b_isEmpty:

--- a/taplt/ui/image_viewer.py
+++ b/taplt/ui/image_viewer.py
@@ -31,6 +31,7 @@ class ImageViewer(QGraphicsView):
                 factor = min(view_rect.width() / scene_rect.width(),
                              view_rect.height() / scene_rect.height())
                 self.scale(factor, factor)
+                self._emit_zoom()
 
     def resizeEvent(self, event: QResizeEvent) -> None:
         bounds = self.scene().itemsBoundingRect()
@@ -42,11 +43,7 @@ class ImageViewer(QGraphicsView):
             if self._enableZoomPan:
                 factor = self._scaling_factor if event.angleDelta().y() > 0 else 1/self._scaling_factor
                 self.scale(factor, factor)
-                # calculate zoom factor + send to CenterDisplayWidget
-                current_zoom = float(self.transform().m11())
-                parent = self.parentWidget()
-                if hasattr(parent, "sZoomChanged"):
-                    parent.sZoomChanged.emit(current_zoom)
+                self._emit_zoom()
 
     def keyPressEvent(self, event) -> None:
         if not self.b_isEmpty:
@@ -63,3 +60,10 @@ class ImageViewer(QGraphicsView):
             if event.key() == Qt.Key.Key_Control:
                 self._enableZoomPan = False
                 self.setDragMode(QGraphicsView.DragMode.NoDrag)
+
+
+    def _emit_zoom(self):
+        current_zoom = float(self.transform().m11())
+        parent = self.parentWidget()
+        if hasattr(parent, "sZoomChanged"):
+            parent.sZoomChanged.emit(current_zoom)

--- a/taplt/ui/main_window.py
+++ b/taplt/ui/main_window.py
@@ -64,6 +64,8 @@ class LabelingMainWindow(QMainWindow):
 
         self.welcome_screen = WelcomeScreen()
         self.file_display = CenterDisplayWidget()
+        self.file_display.sZoomChanged.connect(self.update_zoom_label)
+
 
         # default widget when no images exist in the project
         self.no_files = QLabel()
@@ -113,6 +115,13 @@ class LabelingMainWindow(QMainWindow):
 
         self.statusbar = QStatusBar()
         self.setStatusBar(self.statusbar)
+
+        # zoom level widget
+        self.zoom_label = QLabel("100%")
+        self.zoom_label.setMinimumWidth(60)
+        self.zoom_label.setAlignment(Qt.AlignmentFlag.AlignRight)
+        self.statusbar.addPermanentWidget(self.zoom_label)
+
 
         self.toolBar = Toolbar(self)
         self.addToolBar(Qt.ToolBarArea.LeftToolBarArea, self.toolBar)
@@ -473,3 +482,8 @@ class LabelingMainWindow(QMainWindow):
                    )
         actions = list(actions)
         return actions
+    
+    def update_zoom_label(self, zoom_factor: float):
+        percent = int(zoom_factor * 100)
+        self.zoom_label.setText(f"{percent}%")
+

--- a/taplt/ui/main_window.py
+++ b/taplt/ui/main_window.py
@@ -67,7 +67,7 @@ class LabelingMainWindow(QMainWindow):
         self.file_display.sZoomChanged.connect(self.update_zoom_label)
 
         # zoom label on top right side
-        self.zoom_label = QLabel("100%", self.center_frame)
+        self.zoom_label = QLabel("100%", self.file_display)
         self.zoom_label.setStyleSheet("""
             background-color: rgba(0,0,0,150);
             color: white;
@@ -76,7 +76,6 @@ class LabelingMainWindow(QMainWindow):
             """)
         self.zoom_label.adjustSize()
         self.zoom_label.raise_()
-        self._reposition_zoom_label()
         self.file_display.hide_button.setVisible(False)
 
         # default widget when no images exist in the project
@@ -261,9 +260,6 @@ class LabelingMainWindow(QMainWindow):
         self.toolBar.move(x, y)
         self.toolBar.raise_()
 
-    def resizeEvent(self, event):
-        super(LabelingMainWindow, self).resizeEvent(event)
-        self._position_toolbar()
 
     def import_file(self, existing_patients: list):
         """executes a dialog to let the user enter all information regarding file import"""
@@ -349,6 +345,7 @@ class LabelingMainWindow(QMainWindow):
         """ either hides the default label or the image display"""
         self.file_display.setHidden(b)
         self.no_files.setHidden(not b)
+        self.zoom_label.setVisible(not b)
 
     def set_welcome_screen(self, b: bool):
         """sets or removes the welcome screen displayed when no project is opened"""
@@ -357,6 +354,7 @@ class LabelingMainWindow(QMainWindow):
         self.toolBar.setHidden(b)
         self.right_menu_widget.setHidden(b)
         self.welcome_screen.setHidden(not b)
+        self.zoom_label.setVisible(not b)
 
     def update_window(self, files: list, img_idx, patient: str, classes: list, labels: list):
         """main updating function: all necessary information is passed to the main window"""
@@ -372,6 +370,9 @@ class LabelingMainWindow(QMainWindow):
             self.set_no_files_screen(True)
 
         self.update_toolbar()
+        QTimer.singleShot(50, self._reposition_zoom_label)
+        QTimer.singleShot(50, lambda: (self.zoom_label.setText("100%"), self.zoom_label.adjustSize()))
+        
     def update_toolbar(self):
         self.toolBar.adjustSize()
         self._position_toolbar()
@@ -507,6 +508,7 @@ class LabelingMainWindow(QMainWindow):
         return actions
     def resizeEvent(self, event):
         super().resizeEvent(event)
+        self._position_toolbar()
         self._reposition_zoom_label()
 
     def update_zoom_label(self, zoom_factor: float):
@@ -515,7 +517,9 @@ class LabelingMainWindow(QMainWindow):
         self.zoom_label.adjustSize()
 
     def _reposition_zoom_label(self):
+        if self.file_display.width() == 0:
+            return
         margin = 10
-        x = self.center_frame.width() - self.zoom_label.width() - margin
+        x = self.file_display.width() - self.zoom_label.width() - margin
         self.zoom_label.move(x, margin)
         self.zoom_label.raise_()

--- a/taplt/ui/main_window.py
+++ b/taplt/ui/main_window.py
@@ -66,6 +66,17 @@ class LabelingMainWindow(QMainWindow):
         self.file_display = CenterDisplayWidget()
         self.file_display.sZoomChanged.connect(self.update_zoom_label)
 
+        # zoom label on top right side
+        self.zoom_label = QLabel("100%", self.center_frame)
+        self.zoom_label.setStyleSheet("""
+            background-color: rgba(0,0,0,150);
+            color: white;
+            padding: 2px 6px;
+            border-radius: 3px;
+            """)
+        self.zoom_label.adjustSize()
+        self.zoom_label.raise_()
+        self._reposition_zoom_label()
 
         # default widget when no images exist in the project
         self.no_files = QLabel()
@@ -115,12 +126,6 @@ class LabelingMainWindow(QMainWindow):
 
         self.statusbar = QStatusBar()
         self.setStatusBar(self.statusbar)
-
-        # zoom level widget
-        self.zoom_label = QLabel("100%")
-        self.zoom_label.setMinimumWidth(60)
-        self.zoom_label.setAlignment(Qt.AlignmentFlag.AlignRight)
-        self.statusbar.addPermanentWidget(self.zoom_label)
 
 
         self.toolBar = Toolbar(self)
@@ -482,8 +487,17 @@ class LabelingMainWindow(QMainWindow):
                    )
         actions = list(actions)
         return actions
-    
+    def resizeEvent(self, event):
+        super().resizeEvent(event)
+        self._reposition_zoom_label()
+
     def update_zoom_label(self, zoom_factor: float):
         percent = int(zoom_factor * 100)
         self.zoom_label.setText(f"{percent}%")
+        self.zoom_label.adjustSize()
 
+    def _reposition_zoom_label(self):
+        margin = 10
+        x = self.center_frame.width() - self.zoom_label.width() - margin
+        self.zoom_label.move(x, margin)
+        self.zoom_label.raise_()


### PR DESCRIPTION
resolves #11 
Veränderungen: 
in `main_window.py`
- in __innit__ : zoom label widget anlegen
- Update Methode hinzugefügt

in `file_display.py`
- Signal sZoomChanged

in `image_viewer.py`:
- zoom faktor berechnen + signal an 
`CenterDisplayWidget`  senden

**EDIT:** 

in `main_window.py`: 

- neues zoom label außerhalb der statusbar im rechten oberen Eck
- neue Methode _reposition_zoom_label() damit es sich nach resize event anpasst

in `image_viewer.py`

- signal tatsächlich nach ‘fitInView’ emittieren

in `file_display.py`

- sZoomChanged nach fitInView Aufruf (in init_image) entfernen, da von image_viewer selbst emittiert wird

<img width="1040" height="469" alt="grafik" src="https://github.com/user-attachments/assets/ac8fda12-1208-498e-a606-02a86e1dcd3b" />

Zoom level wird jetzt korrekt geupdated, da die Änderungen aus image_viewer in image_viewer in media_viewing_widget übernommen wurden (file_display nutzt diese Datei)

**in Zukunft noch machen:**
Zoomlevel auch für slide_viewer, momentan nur für images