### PR TITLE
Openslide fuer MacOS und Linux

### DIFF
--- a/download_openslide.py
+++ b/download_openslide.py
@@ -9,52 +9,63 @@ import requests
 from bs4 import BeautifulSoup
 import zipfile
 
-openslide_url = "https://openslide.org/download/"
-
-response = requests.get(openslide_url)
-
-# Determine OS to choose openslide version
-operatingSystem:str = ""
-operatingSystemInformation = platform.uname()
-if operatingSystemInformation.system == "Windows":
-    operatingSystem = "windows-x64" if "64" in operatingSystemInformation.machine else "win32"
-elif operatingSystemInformation.system == "Linux":
-    if "x86_64" in operatingSystemInformation.machine: 
-        operatingSystem = "linux-x86_64"
-    elif "aarch64" in operatingSystemInformation.machine:
-        operatingSystem = "linux-aarch64"
-elif operatingSystemInformation.system == "Darwin":
-    operatingSystem = "macos"
-if operatingSystem == "":
-    raise Exception("Can't determin Operating System, therefore no openslide installation is possible")
+# Check for Openslide Installation
+continueInstalling = True
+if(os.path.isdir("openslide")):
+    userAnswer = input("There is already an Openslide installation. Do you want to continue and overwrite it? [Y/N]")
+    if not (userAnswer.lower in ["y","yes", "j", "ja"]):
+        continueInstalling = False
 
 
-if response.status_code == 200:
-    soup = BeautifulSoup(response.text, 'html.parser')
 
-    download_link = None
-    for link in soup.find_all('a'):
-        if link.get('href') and operatingSystem in link.get('href'):
-            download_link = link.get('href')
-            break
+if continueInstalling:
+    # Determine OS to choose openslide version
+    operatingSystem:str = ""
+    operatingSystemInformation = platform.uname()
+    if operatingSystemInformation.system == "Windows":
+        operatingSystem = "windows-x64" if "64" in operatingSystemInformation.machine else "win32"
+    elif operatingSystemInformation.system == "Linux":
+        if "x86_64" in operatingSystemInformation.machine: 
+            operatingSystem = "linux-x86_64"
+        elif "aarch64" in operatingSystemInformation.machine:
+            operatingSystem = "linux-aarch64"
+    elif operatingSystemInformation.system == "Darwin":
+        operatingSystem = "macos"
+    if operatingSystem == "":
+        raise Exception("Can't determin Operating System, therefore no openslide installation is possible")
 
-    if download_link:
-        filename = os.path.basename(download_link)
+    # Download Openslide
+    openslide_url = "https://openslide.org/download/"
 
-        response = requests.get(download_link)
-        if response.status_code == 200:
-            with open(filename, 'wb') as file:
-                file.write(response.content)
+    response = requests.get(openslide_url)
 
-            with zipfile.ZipFile(filename) as zip_ref:
-                zip_ref.extractall()
+    if response.status_code == 200:
+        soup = BeautifulSoup(response.text, 'html.parser')
 
-            os.remove(filename)
-            os.rename(filename[:-4], "openslide")
-            print(f"Openslide has been successfully downloaded.")
+        download_link = None
+        for link in soup.find_all('a'):
+            if link.get('href') and operatingSystem in link.get('href'):
+                download_link = link.get('href')
+                break
+
+        if download_link:
+            filename = os.path.basename(download_link)
+
+            response = requests.get(download_link)
+            if response.status_code == 200:
+                with open(filename, 'wb') as file:
+                    file.write(response.content)
+
+                with zipfile.ZipFile(filename) as zip_ref:
+                    zip_ref.extractall()
+
+                os.remove(filename)
+                if(os.path.isdir("openslide")): os.remove("openslide") # Overwrite existing installation
+                os.rename(filename[:-4], "openslide")
+                print(f"Openslide has been successfully downloaded.")
+            else:
+                print("Failed to download OpenSlide library.")
         else:
-            print("Failed to download OpenSlide library.")
+            print("Download link not found on the page.")
     else:
-        print("Download link not found on the page.")
-else:
-    print("Failed to access the OpenSlide download page.")
+        print("Failed to access the OpenSlide download page.")

--- a/download_openslide.py
+++ b/download_openslide.py
@@ -8,6 +8,7 @@ import requests
 from bs4 import BeautifulSoup
 import zipfile
 import tarfile
+import shutil
 
 # Check for Openslide Installation
 continueInstalling = True
@@ -58,16 +59,18 @@ if continueInstalling:
                 ending:str = filename.split(".")[-1]
                 if ending == "zip":
                     with zipfile.ZipFile(filename) as zip_ref:
-                        zip_ref.extractall()
+                        zip_ref.extractall("tmp_unpackfolder")
                 elif ending == "xz":
                     with tarfile.TarFile.xzopen(filename) as tar_ref:
-                        tar_ref.extractall()
+                        tar_ref.extractall("tmp_unpackfolder")
                 else:
                     raise Exception("Unknown compression format, can't unpack")
 
                 os.remove(filename)
-                if(os.path.isdir("openslide")): os.remove("openslide") # Overwrite existing installation
-                os.rename(filename[:-4], "openslide")
+                if(os.path.isdir("openslide")): shutil.rmtree("openslide", ignore_errors=True) # Remove existing installation
+                extractedFolder =  os.listdir("tmp_unpackfolder")[0]
+                os.rename("tmp_unpackfolder/"+extractedFolder, "openslide")
+                shutil.rmtree("tmp_unpackfolder", ignore_errors=True)
                 print(f"Openslide has been successfully downloaded.")
             else:
                 print("Failed to download OpenSlide library.")

--- a/download_openslide.py
+++ b/download_openslide.py
@@ -62,7 +62,10 @@ if continueInstalling:
                         zip_ref.extractall("tmp_unpackfolder")
                 elif ending == "xz":
                     with tarfile.TarFile.xzopen(filename) as tar_ref:
-                        tar_ref.extractall("tmp_unpackfolder")
+                        if (platform.python_version()>="3.12"): # Filter works for py3.12+
+                            tar_ref.extractall("unpackfolder", filter = "tar")
+                        else:
+                            tar_ref.extractall("unpackfolder")
                 else:
                     raise Exception("Unknown compression format, can't unpack")
 

--- a/download_openslide.py
+++ b/download_openslide.py
@@ -17,7 +17,7 @@ if response.status_code == 200:
 
     download_link = None
     for link in soup.find_all('a'):
-        if link.get('href') and "openslide-win64" in link.get('href'):
+        if link.get('href') and "windows-x64" in link.get('href'):
             download_link = link.get('href')
             break
 

--- a/download_openslide.py
+++ b/download_openslide.py
@@ -12,9 +12,8 @@ import zipfile
 continueInstalling = True
 if(os.path.isdir("openslide")):
     userAnswer = input("There is already an Openslide installation. Do you want to continue and overwrite it? [Y/N]")
-    if not (userAnswer.lower in ["y","yes", "j", "ja"]):
+    if not (userAnswer.lower() in ["y","yes", "j", "ja"]):
         continueInstalling = False
-
 
 
 if continueInstalling:

--- a/download_openslide.py
+++ b/download_openslide.py
@@ -4,6 +4,7 @@ Only works for windows currently
 """
 #TODO: Makes this work for other operating systems
 import os
+import platform
 import requests
 from bs4 import BeautifulSoup
 import zipfile
@@ -12,12 +13,28 @@ openslide_url = "https://openslide.org/download/"
 
 response = requests.get(openslide_url)
 
+# Determine OS to choose openslide version
+operatingSystem:str = ""
+operatingSystemInformation = platform.uname()
+if operatingSystemInformation.system == "Windows":
+    operatingSystem = "windows-x64" if "64" in operatingSystemInformation.machine else "win32"
+elif operatingSystemInformation.system == "Linux":
+    if "x86_64" in operatingSystemInformation.machine: 
+        operatingSystem = "linux-x86_64"
+    elif "aarch64" in operatingSystemInformation.machine:
+        operatingSystem = "linux-aarch64"
+elif operatingSystemInformation.system == "Darwin":
+    operatingSystem = "macos"
+if operatingSystem == "":
+    raise Exception("Can't determin Operating System, therefore no openslide installation is possible")
+
+
 if response.status_code == 200:
     soup = BeautifulSoup(response.text, 'html.parser')
 
     download_link = None
     for link in soup.find_all('a'):
-        if link.get('href') and "windows-x64" in link.get('href'):
+        if link.get('href') and operatingSystem in link.get('href'):
             download_link = link.get('href')
             break
 

--- a/download_openslide.py
+++ b/download_openslide.py
@@ -7,11 +7,12 @@ import platform
 import requests
 from bs4 import BeautifulSoup
 import zipfile
+import tarfile
 
 # Check for Openslide Installation
 continueInstalling = True
 if(os.path.isdir("openslide")):
-    userAnswer = input("There is already an Openslide installation. Do you want to continue and overwrite it? [Y/N]")
+    userAnswer = input("There is already an Openslide installation. Do you want to continue and overwrite it? [Y/N] ")
     if not (userAnswer.lower() in ["y","yes", "j", "ja"]):
         continueInstalling = False
 
@@ -54,8 +55,15 @@ if continueInstalling:
                 with open(filename, 'wb') as file:
                     file.write(response.content)
 
-                with zipfile.ZipFile(filename) as zip_ref:
-                    zip_ref.extractall()
+                ending:str = filename.split(".")[-1]
+                if ending == "zip":
+                    with zipfile.ZipFile(filename) as zip_ref:
+                        zip_ref.extractall()
+                elif ending == "xz":
+                    with tarfile.TarFile.xzopen(filename) as tar_ref:
+                        tar_ref.extractall()
+                else:
+                    raise Exception("Unknown compression format, can't unpack")
 
                 os.remove(filename)
                 if(os.path.isdir("openslide")): os.remove("openslide") # Overwrite existing installation

--- a/download_openslide.py
+++ b/download_openslide.py
@@ -57,23 +57,24 @@ if continueInstalling:
                     file.write(response.content)
 
                 ending:str = filename.split(".")[-1]
+                tmp_dir = "tmp_unpackfolder"
                 if ending == "zip":
                     with zipfile.ZipFile(filename) as zip_ref:
-                        zip_ref.extractall("tmp_unpackfolder")
+                        zip_ref.extractall(tmp_dir)
                 elif ending == "xz":
                     with tarfile.TarFile.xzopen(filename) as tar_ref:
                         if (platform.python_version()>="3.12"): # Filter works for py3.12+
-                            tar_ref.extractall("unpackfolder", filter = "tar")
+                            tar_ref.extractall(tmp_dir, filter = "tar")
                         else:
-                            tar_ref.extractall("unpackfolder")
+                            tar_ref.extractall(tmp_dir)
                 else:
                     raise Exception("Unknown compression format, can't unpack")
 
                 os.remove(filename)
                 if(os.path.isdir("openslide")): shutil.rmtree("openslide", ignore_errors=True) # Remove existing installation
-                extractedFolder =  os.listdir("tmp_unpackfolder")[0]
-                os.rename("tmp_unpackfolder/"+extractedFolder, "openslide")
-                shutil.rmtree("tmp_unpackfolder", ignore_errors=True)
+                extractedFolder =  os.listdir(tmp_dir)[0]
+                os.rename(tmp_dir+"/"+extractedFolder, "openslide")
+                shutil.rmtree(tmp_dir, ignore_errors=True)
                 print(f"Openslide has been successfully downloaded.")
             else:
                 print("Failed to download OpenSlide library.")

--- a/download_openslide.py
+++ b/download_openslide.py
@@ -2,7 +2,6 @@
 This file is there to download the latest version of openslide from their website.
 Only works for windows currently
 """
-#TODO: Makes this work for other operating systems
 import os
 import platform
 import requests


### PR DESCRIPTION
Openslide Installation: Fixes und Erweiterung

resolves #13 Problem 1

Erweiterung:
- `python download_openslide.py` (ausführen) kann nun auch für Linux und MacOS Betriebssysteme verwendet werden.

Fixes:
- Download neuste Version (aufgrund Umbenennung neuerer Links seit 2024)
- Überschreiben einer alten Installation (Wenn schon ein openslide Folder existiert wird der Benutzer im Terminal gefragt, ob er diesen Überschreiben will, vorher Fehlermeldung)