### PR TITLE
Fix/settings invisible

### DIFF
--- a/taplt/utils/database.py
+++ b/taplt/utils/database.py
@@ -86,12 +86,9 @@ class SQLiteDatabase(QObject):
 
     def __init__(self):
         super(SQLiteDatabase, self).__init__()
-        #self.connection = None
-        #self.cursor = None
         self.location = ""
         self.file_tables = FILE_TABLES
         self.is_initialized = False
-        #self.settings = None  # type: QSettings
         self.database_path = "none"
 
     def add_annotation(self, modality: int, file: int, patient: int, shape: bytes, label: int):

--- a/taplt/utils/database.py
+++ b/taplt/utils/database.py
@@ -86,12 +86,12 @@ class SQLiteDatabase(QObject):
 
     def __init__(self):
         super(SQLiteDatabase, self).__init__()
-        self.connection = None
-        self.cursor = None
+        #self.connection = None
+        #self.cursor = None
         self.location = ""
         self.file_tables = FILE_TABLES
         self.is_initialized = False
-        self.settings = None  # type: QSettings
+        #self.settings = None  # type: QSettings
         self.database_path = "none"
 
     def add_annotation(self, modality: int, file: int, patient: int, shape: bytes, label: int):
@@ -328,10 +328,10 @@ class SQLiteDatabase(QObject):
             self.create_initial_tables()
             for file, patient in files.items():
                 self.add_file(file, patient)
-            self.settings = QSettings(self.location + '/settings', QSettings.Format.NativeFormat)
+            self.settings = QSettings(self.location + '/settings.ini', QSettings.Format.IniFormat)
             self.update_settings(SETTINGS)
         else:
-            self.settings = QSettings(self.location + '/settings', QSettings.Format.NativeFormat)
+            self.settings = QSettings(self.location + '/settings.ini', QSettings.Format.IniFormat)
 
         with self.connection:
             self.cursor.execute(f"PRAGMA foreign_keys = ON;")

--- a/taplt/utils/stylesheets.py
+++ b/taplt/utils/stylesheets.py
@@ -38,7 +38,7 @@ TAB_STYLESHEET = """ QTabWidget::pane {
                      }
                      
                      QTabBar::tab:selected { 
-                     background: white; 
+                     background: rgb(240, 240, 240); 
                      border-left: 1px solid lightgray;
                      border-right: 1px solid lightgray; 
                      border-top: none;

--- a/taplt/utils/stylesheets.py
+++ b/taplt/utils/stylesheets.py
@@ -47,8 +47,5 @@ TAB_STYLESHEET = """ QTabWidget::pane {
                      }
                      """
 
-SETTING_STYLESHEET = """ QListWidget::item {
-                         color: black;
-                         background-color:transparent;
-                         }
+SETTING_STYLESHEET = """ QListWidget::item:hover:!active
                          """


### PR DESCRIPTION
On Windows the Preferences where empty. The Problem was the OSNativeFormat for QSettings, now it is unified to iniFormat. 
Resolves #37 

Remove unnessecary None-declerations, bad style

Additionally there was a Color Problem, especially when hovering in Lightmode, where the Font turned White (invis) but also in Darkmode with darkgray fontcolor

Now:
<img width="302" height="532" alt="grafik" src="https://github.com/user-attachments/assets/b03dee0b-8383-4287-bfdd-9e8ac6d4c528" />