### PR TITLE
Shape 2nd leftclick

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -23,6 +23,19 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: "3.10"
+    - name: Install system dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          libegl1 \
+          libgl1 \
+          libopengl0 \
+          libxkbcommon-x11-0 \
+          libdbus-1-3 \
+          libfontconfig1 \
+          libxrender1 \
+          libxext6 \
+          libsm6
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -36,4 +49,5 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
+        export QT_QPA_PLATFORM=offscreen
         pytest test/

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest
+        pip install flake8 pytest PySide6
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+numpy
+PySide6
+pytest
+flake8

--- a/taplt/ui/annotation_group.py
+++ b/taplt/ui/annotation_group.py
@@ -58,7 +58,10 @@ class AnnotationGroup(QGraphicsObject):
                                     color=self.draw_new_color)
             self.add_shapes(self.temp_shape)
             self.temp_shape.drawingDone.connect(self.set_drawing_to_false)
-            self.sToolTip.emit("Press right click to end the annotation.")
+            if self.shapeType == Shape.ShapeType.POLYGON:
+                self.sToolTip.emit("Press right click to end the annotation.")
+            else:
+                self.sToolTip.emit("Press left click a 2nd time to end the annotation.")       
             self.temp_shape.grabMouse()
         else:
             pass

--- a/taplt/ui/shape.py
+++ b/taplt/ui/shape.py
@@ -169,7 +169,14 @@ class Shape(QGraphicsObject):
                 else:                                          
                     if len(self.vertices.vertices) == 0:
                         self.vertices.vertices.append(point)
-                self.update()
+                    else:
+                        self.vertices.vertices.append(point)
+                        self.ungrabMouse() 
+                        self.is_closed_path = True
+                        self.drawingDone.emit()
+                        event.accept()
+                        return 
+                self.update()   
             elif self.contains(event.pos()):
                 self.setSelected(True)
                 self.selected.emit()
@@ -178,7 +185,7 @@ class Shape(QGraphicsObject):
             else:
                 event.ignore()
         elif event.button() == Qt.MouseButton.RightButton:
-            if self.mode == Shape.ShapeMode.CREATE and len(self.vertices.vertices) > 1:
+            if self.shape_type == "polygon" and self.mode == Shape.ShapeMode.CREATE and len(self.vertices.vertices) > 1:
                 self.ungrabMouse()
                 self.is_closed_path = True
 
@@ -310,7 +317,7 @@ class Shape(QGraphicsObject):
         if self.shape_type not in ['polygon', 'rectangle', 'ellipse', 'circle', 'trace', 'tempPolygon', 'point']:
             raise AttributeError("Unsupported Shape: " + str(self.shape_type))
         # Add additional points
-        if self.shape_type in ['rectangle', 'ellipse', 'circle'] and len(self.vertices.vertices) == 2:
+        if self.shape_type in ['rectangle', 'ellipse'] and len(self.vertices.vertices) == 2:
             self.vertices.complete_poly()
 
         # Generate path for the temporary Shapes
@@ -382,10 +389,10 @@ class Shape(QGraphicsObject):
                     painter.drawEllipse(QRectF(self.vertices.vertices[0], self.vertices.vertices[len(self.vertices.vertices)//2]))
                 elif self.shape_type == "circle":
                     center = self.vertices.vertices[0]
-                    if len(self.vertices.vertices) == 2:
-                        second_point = self.vertices.vertices[1]
-                    elif len(self.vertices.vertices) == 4:
-                        second_point = self.vertices.vertices[2]
+                    if len(self.vertices.vertices) < 2:
+                        return
+                    center = self.vertices.vertices[0]
+                    second_point = self.vertices.vertices[1]
                     radius = math.sqrt(
                         (center.x() - second_point.x()) ** 2 + 
                         (center.y() - second_point.y()) ** 2

--- a/test/shape_test.py
+++ b/test/shape_test.py
@@ -1,13 +1,12 @@
 import sys
 import pytest
-from PySide6.QtWidgets import QApplication, QGraphicsScene, QMainWindow, QWidget, QVBoxLayout, QLabel, QTabWidget, QGraphicsSceneMouseEvent
+from PySide6.QtWidgets import QApplication, QGraphicsScene, QGraphicsSceneMouseEvent
 from PySide6.QtCore import QSize, QPointF, QEvent
-from PySide6.QtGui import QMouseEvent
 from PySide6.QtGui import Qt
 from taplt.ui.shape import Shape
 
 
-app = QApplication(sys.argv)
+app = QApplication.instance() or QApplication(sys.argv)
 
 def make_mouse_event(pos: QPointF, button=Qt.MouseButton.LeftButton):
     event = QGraphicsSceneMouseEvent(QEvent.GraphicsSceneMousePress)

--- a/test/shape_test.py
+++ b/test/shape_test.py
@@ -1,0 +1,38 @@
+import sys
+import pytest
+from PySide6.QtWidgets import QApplication, QGraphicsScene, QMainWindow, QWidget, QVBoxLayout, QLabel, QTabWidget, QGraphicsSceneMouseEvent
+from PySide6.QtCore import QSize, QPointF, QEvent
+from PySide6.QtGui import QMouseEvent
+from PySide6.QtGui import Qt
+from taplt.ui.shape import Shape
+
+
+app = QApplication(sys.argv)
+
+def make_mouse_event(pos: QPointF, button=Qt.MouseButton.LeftButton):
+    event = QGraphicsSceneMouseEvent(QEvent.GraphicsSceneMousePress)
+    event.setButton(button)
+    event.setPos(pos)
+    return event
+
+def test_rectangle_closes_after_2_points():
+    scene = QGraphicsScene()
+    shape = Shape(image_size=QSize(500, 500), 
+                    shape_type=Shape.ShapeType.RECTANGLE, 
+                    mode=Shape.ShapeMode.CREATE)
+    scene.addItem(shape)
+    shape.mousePressEvent(make_mouse_event(QPointF(100, 200)))
+    assert len (shape.vertices.vertices) == 1
+    assert shape.is_closed_path == False
+
+    shape.mousePressEvent(make_mouse_event(QPointF(300, 400)))
+    assert shape.is_closed_path == True
+
+def test_circle_not_closed_after_1_point():
+    scene = QGraphicsScene()
+    shape = Shape(image_size=QSize(500, 500), 
+                    shape_type=Shape.ShapeType.CIRCLE, 
+                    mode=Shape.ShapeMode.CREATE)
+    scene.addItem(shape)
+    shape.mousePressEvent(make_mouse_event(QPointF(100, 200)))
+    assert shape.is_closed_path == False


### PR DESCRIPTION
resolves #34 

- Alle Formen außer Polygon werden mit einem 2. Linksklick beendet
- Die Tooltip messages wurden entsprechend angepasst zu: "Press left click a 2nd time to end the annotation."
- Tests hinzugefügt in shape_test.py