### PR TITLE
Implement draggable floating toolbar

### DIFF
--- a/taplt/ui/main_window.py
+++ b/taplt/ui/main_window.py
@@ -127,11 +127,10 @@ class LabelingMainWindow(QMainWindow):
         self.statusbar = QStatusBar()
         self.setStatusBar(self.statusbar)
 
-
         self.toolBar = Toolbar(self.center_frame)
         self.toolBar.show()
         self.toolBar.raise_() 
-        QTimer.singleShot(0, self.update_toolbar)
+        QTimer.singleShot(0, self._position_toolbar)
 
         # Toolbar setup actions for images, videos and whole slides
         self.toolBar.init_actions('image', self.define_img_actions())
@@ -375,7 +374,10 @@ class LabelingMainWindow(QMainWindow):
         
     def update_toolbar(self):
         self.toolBar.adjustSize()
-        self._position_toolbar()
+        
+        if not self.toolBar._moved_by_user:
+            self._position_toolbar()
+
 
     def define_img_actions(self):
         actions = (Action(self,
@@ -521,9 +523,15 @@ class LabelingMainWindow(QMainWindow):
                    )
         actions = list(actions)
         return actions
+    
     def resizeEvent(self, event):
         super().resizeEvent(event)
-        self._position_toolbar()
+
+        if not self.toolBar._moved_by_user:
+            self._position_toolbar()
+        else: 
+            self.toolBar._clamp_to_parent()
+        
         self._reposition_zoom_label()
 
     def update_zoom_label(self, zoom_factor: float):

--- a/taplt/ui/toolbar.py
+++ b/taplt/ui/toolbar.py
@@ -45,6 +45,7 @@ class Toolbar(QWidget):
 
         self._dragging = False
         self._drag_start_pos = QPoint()
+        self._drag_start_global = QPoint()
         self._moved_by_user = False
 
         self.layout().addWidget(self.toggle_button)
@@ -242,15 +243,21 @@ class Toolbar(QWidget):
             # Start dragging on mouse press
             if event.type() == QEvent.Type.MouseButtonPress:
                 self._dragging = True
-                self._drag_start_pos = event.globalPosition().toPoint() - self.pos()
-                return False  # wichtig: Event weitergeben
+                self._drag_start_global = event.globalPosition().toPoint()
+                self._drag_start_pos =  self.pos() # event.globalPosition().toPoint() - self.pos()
+                self._moved_by_user = False
+                return True 
 
             # Dragging
             elif event.type() == QEvent.Type.MouseMove:
                 if self._dragging:
-                    new_pos = event.globalPosition().toPoint() - self._drag_start_pos
+                    delta = event.globalPosition().toPoint() - self._drag_start_global
 
-                    self._moved_by_user = True
+                    # Only consider it a user move if the mouse has moved a certain distance to avoid accidental drags
+                    if delta.manhattanLength() > QApplication.startDragDistance():
+                        self._moved_by_user = True
+                    
+                    new_pos = self._drag_start_pos + delta
 
                     parent = self.parentWidget()
                     if parent:
@@ -264,11 +271,15 @@ class Toolbar(QWidget):
                     else:
                         self.move(new_pos)
 
-                return False
+                return True
 
             # Stop dragging on mouse release
             elif event.type() == QEvent.Type.MouseButtonRelease:
                 self._dragging = False
-                return False
+
+                if not self._moved_by_user:
+                        self.toggle_button.click()
+
+                return True
 
         return super().eventFilter(obj, event)

--- a/taplt/ui/toolbar.py
+++ b/taplt/ui/toolbar.py
@@ -39,6 +39,13 @@ class Toolbar(QWidget):
         self.toggle_button.setCheckable(True)
         self.toggle_button.setChecked(True)
         self.toggle_button.clicked.connect(self._toggle_visibility)
+        self.toggle_button.setCursor(Qt.CursorShape.SizeAllCursor)
+        self.toggle_button.setMouseTracking(True)
+        self.toggle_button.installEventFilter(self)
+
+        self._dragging = False
+        self._drag_start_pos = QPoint()
+        self._moved_by_user = False
 
         self.layout().addWidget(self.toggle_button)
 
@@ -136,6 +143,7 @@ class Toolbar(QWidget):
             self.addActions(self.modality_dict[modality_name])  
 
             QTimer.singleShot(0, self.sRequestUpdate.emit)
+
     def clear_actions(self):
         """
         This method removes all actions that are currently active, from the toolbar.
@@ -160,6 +168,107 @@ class Toolbar(QWidget):
         self.adjustSize()
 
         parent = self.parentWidget()
-        if parent and hasattr(parent, "_position_toolbar"):
+        if parent and hasattr(parent, "_position_toolbar") and not self._moved_by_user:
             parent._position_toolbar()
+        else:
+            self._clamp_to_parent()
         
+    def mousePressEvent(self, event):
+        """ 
+        This method is responsible for handling the mouse press event on the toolbar. 
+        It starts dragging when the left mouse button is pressed.
+        """
+        if event.button() == Qt.LeftButton:
+            # Don't drag if clicking on a tool button (other than toggle button)
+            if not self.toggle_button.geometry().contains(event.pos()):
+                return
+            
+            self._dragging = True
+            self._drag_start_pos = event.globalPosition().toPoint() - self.pos()
+            event.accept()
+
+    def mouseMoveEvent(self, event):
+        """
+        This method is responsible for handling the mouse move event on the toolbar. 
+        It moves the toolbar if dragging is active and ensures that the toolbar stays within the bounds of its parent widget.
+        """
+        if self._dragging:
+            new_pos = event.globalPosition().toPoint() - self._drag_start_pos
+            
+            self._moved_by_user = True
+
+            parent = self.parentWidget()
+            if parent:
+                parent_rect = parent.rect()
+                toolbar_rect = self.rect()
+
+                # Ensure the toolbar stays within the parent's bounds
+                new_x = max(0, min(new_pos.x(), parent_rect.width() - toolbar_rect.width()))
+                new_y = max(0, min(new_pos.y(), parent_rect.height() - toolbar_rect.height()))
+
+                self.move(new_x, new_y)
+            else:   
+                self.move(new_pos)
+
+            event.accept()
+        
+    def mouseReleaseEvent(self, event):
+        """
+        This method is responsible for handling the mouse release event on the toolbar.
+        It stops dragging when the left mouse button is released.
+        """
+        if event.button() == Qt.LeftButton:
+            self._dragging = False
+            event.accept()
+
+    def _clamp_to_parent(self):
+        """Ensure the toolbar stays within the bounds of its parent widget."""
+        parent = self.parentWidget()
+        if parent:
+            parent_rect = parent.rect()
+            toolbar_rect = self.rect()
+            current_pos = self.pos()
+
+            new_x = max(0, min(current_pos.x(), parent_rect.width() - toolbar_rect.width()))
+            new_y = max(0, min(current_pos.y(), parent_rect.height() - toolbar_rect.height()))
+
+            self.move(new_x, new_y)
+
+    def eventFilter(self, obj, event):
+        """
+        This method is responsible for filtering events on the toggle button to allow dragging the toolbar by clicking and dragging the toggle button.
+        """
+        if obj == self.toggle_button:
+            # Start dragging on mouse press
+            if event.type() == QEvent.Type.MouseButtonPress:
+                self._dragging = True
+                self._drag_start_pos = event.globalPosition().toPoint() - self.pos()
+                return False  # wichtig: Event weitergeben
+
+            # Dragging
+            elif event.type() == QEvent.Type.MouseMove:
+                if self._dragging:
+                    new_pos = event.globalPosition().toPoint() - self._drag_start_pos
+
+                    self._moved_by_user = True
+
+                    parent = self.parentWidget()
+                    if parent:
+                        max_x = parent.width() - self.width()
+                        max_y = parent.height() - self.height()
+
+                        x = max(0, min(new_pos.x(), max_x))
+                        y = max(0, min(new_pos.y(), max_y))
+
+                        self.move(x, y)
+                    else:
+                        self.move(new_pos)
+
+                return False
+
+            # Stop dragging on mouse release
+            elif event.type() == QEvent.Type.MouseButtonRelease:
+                self._dragging = False
+                return False
+
+        return super().eventFilter(obj, event)


### PR DESCRIPTION
Resolves #23 

Toolbar kann über Drag & Drop verschoben werden und ist weiterhin ein- und ausklappbar.
- Drag funktioniert über den Toggle-Button (nicht optimal -> neues Issue für einen Drag Header)
- Toolbar bleibt nach Drag an dieser Position

### Änderungen

#### `toolbar.py`
- `Toolbar.__init__`: neue Attribute für Drag-Verhalten hinzugefügt, Toggle-Button als Drag-Zone festgelegt
- `eventFilter()` hinzugefügt, für Drag & Drop Implementierung
- `_clamp_to_parent()` hinzugefügt, die die Bewegung der Toolbar auf das Parent-Widget begrenzt
- `_toggle_visibility()` angepasst, sodass die Toolbar nach manueller Positionierung nicht mehr automatisch neu positioniert wird

#### `main_window.py`

- Initiale Positionierung der Toolbar über `_position_toolbar()` (statt über `update_toolbar()`)
- `update_toolbar()` angepasst, sodass sie die Toolbar nur positioniert, wenn sie noch nicht manuell verschoben wurde
- `resizeEvent()` angepasst, sodass die Toolbar nur automatisch positioniert wird, wenn sie noch nicht vom User bewegt wurde, sonst wird nur sichergestellt, dass sie im sichtbaren Bereich bleibt

#### Drag vs Click Verhalten
Beim Dragging über den Toggle-Button wurde gleichzeitig ein Click-Event ausgelöst, sodass sich die Toolbar beim Verschieben ein- oder ausgeklappt hat.

**Lösung:** 
Unterscheidung zwischen Click und Drag anhand der Mausbewegung (`startDragDistance`). Der Toggle wird nur ausgelöst, wenn keine Bewegung der Maus stattfindet.