### PR TITLE
increase font size

### DIFF
--- a/taplt/__main__.py
+++ b/taplt/__main__.py
@@ -2,11 +2,17 @@ import argparse
 import sys
 
 from PySide6.QtWidgets import QApplication
+from PySide6.QtGui import QFont
 from taplt.src.main_logic import MainLogic
+from taplt.utils.stylesheets import BASE_FONT_SIZE
 
 
 def main(_args):
     app = QApplication(sys.argv)
+    # Set global application font size
+    global_font = QFont()
+    global_font.setPointSize(BASE_FONT_SIZE)
+    app.setFont(global_font)
     _ = MainLogic()  # the labeling window
     sys.exit(app.exec())
 

--- a/taplt/macros/macros_dialogs.py
+++ b/taplt/macros/macros_dialogs.py
@@ -3,7 +3,7 @@ from PySide6.QtCore import QSize, Qt
 from PySide6.QtGui import QFont
 
 from pathlib import Path
-from taplt.utils.stylesheets import BUTTON_STYLESHEET
+from taplt.utils.stylesheets import BUTTON_STYLESHEET, BASE_FONT_SIZE
 
 
 class ExampleProjectDialog(QDialog):
@@ -16,10 +16,10 @@ class ExampleProjectDialog(QDialog):
         self.info = QLabel()
         self.info.setWordWrap(True)
         self.info.setText("Click the button below to create a new project with some example images \n")
-        self.info.setFont(QFont("Helvetica", 15, QFont.Weight.Bold))
+        self.info.setFont(QFont("Helvetica", BASE_FONT_SIZE + 2, QFont.Weight.Bold))
 
         self.button = QPushButton("Show me an example project")
-        self.button.setStyleSheet(BUTTON_STYLESHEET)
+        self.button.setStyleSheet(BUTTON_STYLESHEET.format(button_size=BASE_FONT_SIZE + 1))
         self.button.clicked.connect(self.finish)
 
         self.layout().addWidget(self.info)
@@ -72,7 +72,7 @@ class PreviewDatabaseDialog(QDialog):
                 self.table.setItem(i, j, item)
 
         self.button = QPushButton("Close")
-        self.button.setStyleSheet(BUTTON_STYLESHEET)
+        self.button.setStyleSheet(BUTTON_STYLESHEET.format(button_size=BASE_FONT_SIZE + 1))
         self.button.setFixedSize(80, 60)
         self.button.pressed.connect(self.close)
 

--- a/taplt/ui/dialogs.py
+++ b/taplt/ui/dialogs.py
@@ -9,7 +9,7 @@ import os
 
 from taplt.ui.list_widgets import LabelList, SettingList
 from taplt.utils.qt import get_icon
-from taplt.utils.stylesheets import BUTTON_STYLESHEET
+from taplt.utils.stylesheets import BUTTON_STYLESHEET, BASE_FONT_SIZE
 
 
 class CloseMessageBox(QMessageBox):
@@ -248,7 +248,7 @@ class ProjectHandlerDialog(QDialog):
 
         # Header for LineEdit
         self.header = QLabel()
-        self.header.setStyleSheet("font: bold 12px")
+        self.header.setStyleSheet(f"font: bold {BASE_FONT_SIZE + 2}px")
         self.header.setText("Choose Project Location")
 
         # LineEdit where user can enter a path
@@ -266,14 +266,14 @@ class ProjectHandlerDialog(QDialog):
         # button to open up a FileDialog
         self.select_path_button = QPushButton()
         self.select_path_button.setFixedSize(QSize(40, 30))
-        self.select_path_button.setStyleSheet(BUTTON_STYLESHEET)
+        self.select_path_button.setStyleSheet(BUTTON_STYLESHEET.format(button_size=BASE_FONT_SIZE + 1))
         self.select_path_button.setText('...')
         self.select_path_button.clicked.connect(self.select_path)
 
         # button to add initial files
         self.add_files_button = QPushButton()
         self.add_files_button.setFixedWidth(180)
-        self.add_files_button.setStyleSheet(BUTTON_STYLESHEET)
+        self.add_files_button.setStyleSheet(BUTTON_STYLESHEET.format(button_size=BASE_FONT_SIZE + 1))
         self.add_files_button.setText("Add files to get started")
         self.add_files_button.clicked.connect(self.add_files)
 
@@ -421,7 +421,7 @@ class SettingDialog(QDialog):
         self.setWindowTitle("Settings")
 
         self.header = QLabel("Enter your preferences")
-        self.header.setStyleSheet("font: bold 12px")
+        self.header.setStyleSheet(f"font: bold {BASE_FONT_SIZE + 2}px")
         self.preferences = SettingList(settings)
         self.settings = list()
 

--- a/taplt/ui/list_widgets.py
+++ b/taplt/ui/list_widgets.py
@@ -5,9 +5,11 @@ from PySide6.QtGui import *
 import os
 from typing import List
 
+from taplt.utils.stylesheets import BASE_FONT_SIZE
+
 from taplt.ui.shape import Shape
 from taplt.utils.qt import createListWidgetItemWithSquareIcon, get_icon
-from taplt.utils.stylesheets import TAB_STYLESHEET, SETTING_STYLESHEET
+from taplt.utils.stylesheets import TAB_STYLESHEET, SETTING_STYLESHEET, BASE_FONT_SIZE
 
 
 class FileList(QListWidget):
@@ -101,7 +103,7 @@ class FileViewingWidget(QWidget):
 
         self.tab = QTabWidget()
         self.tab.setContentsMargins(0, 0, 0, 0)
-        self.tab.setStyleSheet(TAB_STYLESHEET)
+        self.tab.setStyleSheet(TAB_STYLESHEET.format(tab_size=BASE_FONT_SIZE))
         self.search_field = QTextEdit()
 
         # Size Policy
@@ -112,7 +114,7 @@ class FileViewingWidget(QWidget):
         self.search_field.setSizePolicy(size_policy)
         self.search_field.setMaximumHeight(25)
         font = QFont()
-        font.setPointSize(10)
+        font.setPointSize(BASE_FONT_SIZE)
         font.setKerning(True)
 
         self.search_field.setFont(font)

--- a/taplt/ui/welcome_screen.py
+++ b/taplt/ui/welcome_screen.py
@@ -4,6 +4,7 @@ from PySide6.QtWidgets import QWidget, QHBoxLayout, QLabel
 from PySide6.QtGui import QFont
 from PySide6.QtCore import Qt
 from taplt import source_directory
+from taplt.utils.stylesheets import BASE_FONT_SIZE
 
 
 class WelcomeScreen(QWidget):
@@ -15,7 +16,7 @@ class WelcomeScreen(QWidget):
         self.label.setText("Welcome to the \n \n"
                            "All-Purpose Labeling Tool \n \n \n"
                            "Create or open a project to get started")
-        self.label.setFont(QFont("Helvetica", 15, QFont.Weight.Bold))
+        self.label.setFont(QFont("Helvetica", BASE_FONT_SIZE + 2, QFont.Weight.Bold))
         self.label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         icon = os.path.join(source_directory, 'icons', 'welcome.jpg').replace("\\", "/")
         self.label.setStyleSheet(f"background-image: url('{icon}');"

--- a/taplt/utils/stylesheets.py
+++ b/taplt/utils/stylesheets.py
@@ -1,50 +1,53 @@
-BUTTON_STYLESHEET = """QPushButton {
+BASE_FONT_SIZE = 11
+
+BUTTON_STYLESHEET = """QPushButton {{
                        background-color: lightgray;
                        color: black;
                        min-height: 2em;
                        border-width: 2px;
                        border-radius: 8px;
                        border-color: black;
-                       font: bold 12px;
+                       font: bold {{button_size}}px;
                        padding: 2px;
-                       }
+                       }}
                        
-                       QPushButton::hover {
+                       QPushButton::hover {{
                        background-color: gray;
-                       }
+                       }}
                        
-                       QPushButton::pressed {
+                       QPushButton::pressed {{
                        border-style: outset;
-                       }
+                       }}
                        """
 
-TAB_STYLESHEET = """ QTabWidget::pane {
+TAB_STYLESHEET = """ QTabWidget::pane {{
                      border: 1px solid lightgray;
                      top:-1px;
-                     } 
+                     }} 
                      
-                     QTabWidget::tab-bar {
+                     QTabWidget::tab-bar {{
                      left: 0px;
-                     }
+                     }}
                      
-                     QTabBar::tab {
+                     QTabBar::tab {{
                      background: rgb(205, 205, 212);
                      min-width: 8ex; 
                      padding: 7px;
-                     } 
+                     font-size: {{tab_size}}px;
+                     }}
                      
-                     QTabBar::tab:hover { 
+                     QTabBar::tab:hover {{ 
                      background: rgb(220, 220, 220);
-                     }
+                     }}
                      
-                     QTabBar::tab:selected { 
+                     QTabBar::tab:selected {{
                      background: rgb(240, 240, 240); 
                      border-left: 1px solid lightgray;
                      border-right: 1px solid lightgray; 
                      border-top: none;
                      border-bottom: none;
                      font: bold;
-                     }
+                     }}
                      """
 
 SETTING_STYLESHEET = """ QListWidget::item:hover:!active

--- a/test/manual_ui_testing.py
+++ b/test/manual_ui_testing.py
@@ -11,7 +11,7 @@ from taplt.ui.shape import Shape
 from taplt.ui.toolbar import Toolbar
 from taplt.src.main_logic import MainLogic
 from taplt.utils.qt import colormap_rgb
-from taplt.utils.stylesheets import TAB_STYLESHEET
+from taplt.utils.stylesheets import TAB_STYLESHEET, BASE_FONT_SIZE
 
 
 COLORS, _ = colormap_rgb(25)
@@ -153,7 +153,7 @@ def test_tab():
     w2.layout().addWidget(QLabel("Widget 2"))
     tab.addTab(w1, 'First')
     tab.addTab(w2, 'Second')
-    tab.setStyleSheet(TAB_STYLESHEET)
+    tab.setStyleSheet(TAB_STYLESHEET.format(tab_size=BASE_FONT_SIZE))
     tab.show()
     app.exec()
 


### PR DESCRIPTION
Resolves #15 

Die Schriftgrößen von Toolbar, Menüs, Seitenpanels und Dialogen wurden für eine bessere Lesbarkeit angepasst und zentralisiert. 
Dafür wurde eine `BASE_FONT_SIZE` eingeführt und die Schrift global über `app.setFont` gesetzt.

### Änderungen

- Einführung von `BASE_FONT_SIZE = 11` als Basis für die Schriftgrößen
- Globale Schriftgröße über `app.setFont(...)`
- Entfernung von festen Schriftgrößen 
- Anpassung von Buttons, Tabs und Textfeldern 

### Vorher 
<img width="1915" height="1000" alt="alt" src="https://github.com/user-attachments/assets/c751a473-c0b6-4a0a-ba52-668e862deb6a" />

### Nachher
<img width="1918" height="1003" alt="neu" src="https://github.com/user-attachments/assets/26ce34a9-5ab4-4793-ae5f-0f2a21440e14" />
