### PR TITLE
label popup mit enter taste

### DIFF
--- a/taplt/media_viewing_widgets/widgets/image_viewer.py
+++ b/taplt/media_viewing_widgets/widgets/image_viewer.py
@@ -5,6 +5,7 @@ from PySide6.QtWidgets import *
 
 class ImageViewer(QGraphicsView):
     sNextFile = Signal(int)
+    sEnterPressed = Signal()
 
     def __init__(self, *args):
         super(ImageViewer, self).__init__(*args)
@@ -55,6 +56,8 @@ class ImageViewer(QGraphicsView):
                 self.sNextFile.emit(-1)
             elif event.key() == Qt.Key.Key_Right:
                 self.sNextFile.emit(1)
+            elif event.key() == Qt.Key.Key_Return or event.key() == Qt.Key.Key_Enter:
+                self.sEnterPressed.emit()
 
     def keyReleaseEvent(self, event) -> None:
         if not self.b_isEmpty:

--- a/taplt/ui/annotation_group.py
+++ b/taplt/ui/annotation_group.py
@@ -3,6 +3,7 @@ from PySide6.QtCore import *
 from typing import *
 from dataclasses import dataclass
 
+from taplt.ui import shape
 from taplt.utils.qt import colormap_rgb
 from taplt.ui.shape import Shape
 from taplt.ui.dialogs import NewLabelDialog, DeleteShapeMessageBox
@@ -35,6 +36,7 @@ class AnnotationGroup(QGraphicsObject):
         self.mode = AnnotationGroup.AnnotationMode.EDIT
         self.shapeType = Shape.ShapeType.POLYGON
         self.drawing = False
+        self.pending_shapes = []
 
     def boundingRect(self):
         return self.childrenBoundingRect()
@@ -97,7 +99,9 @@ class AnnotationGroup(QGraphicsObject):
             shape.selected.connect(self.shape_selected)
             shape.deleted.connect(lambda: self.remove_shapes(shape))
             shape.mode_changed.connect(self.shape_mode_changed)
-            shape.drawingDone.connect(self.set_label)
+            shape.labelRequested.connect(self.set_pending_label)
+            shape.drawingDone.connect(lambda s=shape: self.pending_shapes.append(s))
+            shape.drawingDone.connect(self.set_drawing_to_false)
             shape.sChange.connect(self.sChange.emit)
             self.update()
 
@@ -134,6 +138,7 @@ class AnnotationGroup(QGraphicsObject):
         Clears the group and scene of shapes
         :return:
         """
+        self.pending_shapes.clear()
         self.remove_shapes(list(self.annotations.values()))
 
     def shape_selected(self):
@@ -148,13 +153,13 @@ class AnnotationGroup(QGraphicsObject):
     def shape_mode_changed(self, mode: Union[int, Shape.ShapeMode]):
         shape = self.sender()  # type: Shape
         if mode == Shape.ShapeMode.FIXED:
-            shape.update_color(self.color_map[shape.group_id])
+            if shape.group_id is not None:
+                shape.update_color(self.color_map[shape.group_id])
 
-    def set_label(self):
-        """
-        opens a dialog to let user enter a label
-        :return: None
-        """
+    def set_pending_label(self):
+        #opens a dialog to let user enter a label
+        #:return: None
+        
         dlg = NewLabelDialog(self.classes, self.color_map)
         dlg.exec()
         label = dlg.result
@@ -163,16 +168,19 @@ class AnnotationGroup(QGraphicsObject):
         if label:
             if label not in self.classes:
                 self.classes.append(label)
-            self.temp_shape.group_id = self.classes.index(label)
-            self.temp_shape.label = label
-            self.temp_shape.set_mode(Shape.ShapeMode.FIXED)
+            group_id = self.classes.index(label)
+            for shape in self.pending_shapes:
+                shape.group_id = group_id
+                shape.label = label
+                shape.set_mode(Shape.ShapeMode.FIXED)
+            
+            self.pending_shapes.clear()
             self.updateShapes.emit(list(self.annotations.values()))
             self.sChange.emit(0)
 
-        # if user entered no label, remove shape
+        # if user entered no label, keep pending shapes
         else:
-            self.remove_shapes([self.temp_shape])
-            self.set_drawing_to_false()
+            pass
 
     def set_mode(self, mode: Union[AnnotationMode, int]):
         self.mode = mode

--- a/taplt/ui/annotation_group.py
+++ b/taplt/ui/annotation_group.py
@@ -135,6 +135,11 @@ class AnnotationGroup(QGraphicsObject):
                 ids_to_remove.append(shape_id)
                 self.annotations[shape_id].deleteLater()
         [(self.annotations[x].disconnect(self.annotations[x]), self.annotations.pop(x)) for x in ids_to_remove]
+        updated_pending_shapes = []
+        for shape in self.pending_shapes:
+            if shape not in shapes:
+                updated_pending_shapes.append(shape)
+        self.pending_shapes = updated_pending_shapes
         self.updateShapes.emit(list(self.annotations.values()))
 
     def clear(self):

--- a/taplt/ui/annotation_group.py
+++ b/taplt/ui/annotation_group.py
@@ -47,7 +47,11 @@ class AnnotationGroup(QGraphicsObject):
     @Slot()
     def set_drawing_to_false(self):
         self.drawing = False
-        self.sToolTip.emit("")
+        #print(f"[set_drawing_to_false] pending_shapes={len(self.pending_shapes)}")
+        if self.pending_shapes:
+            self.sToolTip.emit("Press Enter to label all annotations.")
+        else: 
+            self.sToolTip.emit("")
 
     @Slot()
     def create_shape(self):

--- a/taplt/ui/annotation_tree.py
+++ b/taplt/ui/annotation_tree.py
@@ -171,7 +171,8 @@ class AnnotationTree(QTreeWidget):
         for item in self.selectedItems():
             item.setSelected(False)
         item = self.get_item_by_shape(shape)
-        item.setSelected(True)
+        if item is not None:
+            item.setSelected(True)
 
     def update_polygons(self, current_labels: List[Shape]):
         """updates the treeWidget with the specified labels"""

--- a/taplt/ui/file_display.py
+++ b/taplt/ui/file_display.py
@@ -22,6 +22,7 @@ class CenterDisplayWidget(QWidget):
     sDrawingTooltip = Signal(str)
     modalitySwitched = Signal(str)
     sZoomChanged = Signal(float)
+    sEnterPressed = Signal()
 
     CREATE, EDIT = 0, 1
 

--- a/taplt/ui/file_display.py
+++ b/taplt/ui/file_display.py
@@ -65,12 +65,12 @@ class CenterDisplayWidget(QWidget):
         self.layout.addWidget(self.patient_label)
 
         self.image_viewer.sEnterPressed.connect(self.on_enter_pressed)
-    
-        def on_enter_pressed(self):
-            if self.annotations.pending_shapes:          
-                self.annotations.set_pending_label()
 
         self.slide_viewer.sZoomChanged.connect(self.sZoomChanged)
+    
+    def on_enter_pressed(self):
+            if self.annotations.pending_shapes:          
+                self.annotations.set_pending_label()
 
     def mousePressEvent(self, event: QMouseEvent):
         if self.annotations.mode == AnnotationGroup.AnnotationMode.DRAW:

--- a/taplt/ui/file_display.py
+++ b/taplt/ui/file_display.py
@@ -63,6 +63,12 @@ class CenterDisplayWidget(QWidget):
         # self.layout.addWidget(self.slide_wrapper)
         self.layout.addWidget(self.patient_label)
 
+        self.image_viewer.sEnterPressed.connect(self.on_enter_pressed)
+    
+        def on_enter_pressed(self):
+            if self.annotations.pending_shapes:          
+                self.annotations.set_pending_label()
+
         self.slide_viewer.sZoomChanged.connect(self.sZoomChanged)
 
     def mousePressEvent(self, event: QMouseEvent):

--- a/taplt/ui/shape.py
+++ b/taplt/ui/shape.py
@@ -228,12 +228,12 @@ class Shape(QGraphicsObject):
 
 
     def mouseDoubleClickEvent(self, event: QGraphicsSceneMouseEvent):
-        if self.mode == Shape.ShapeMode.FIXED or self.mode == Shape.ShapeMode.EDIT:
-            self.labelRequested.emit()
-            event.accept()
-            return
-        super().mouseDoubleClickEvent(event)
-
+        if self.contains(event.pos()):
+            self.set_mode(Shape.ShapeMode.EDIT)
+        else:
+            event.ignore()
+        super(Shape, self).mouseDoubleClickEvent(event)
+    
     @Slot(QGraphicsSceneMouseEvent)
     def mouseReleaseEvent(self, event: QGraphicsSceneMouseEvent) -> None:
         super(Shape, self).mousePressEvent(event)

--- a/taplt/ui/shape.py
+++ b/taplt/ui/shape.py
@@ -21,8 +21,8 @@ class Shape(QGraphicsObject):
     mode_changed = Signal(int)
     deleted = Signal()
     drawingDone = Signal()
-    sChange = Signal(int)
     sIllegalCircleOnBorder = Signal()
+    labelRequested = Signal()
 
     @dataclass
     class ShapeMode:
@@ -205,6 +205,7 @@ class Shape(QGraphicsObject):
                         self.vertices.vertices.append(point)
                         self.ungrabMouse() 
                         self.is_closed_path = True
+                        self.set_mode(Shape.ShapeMode.FIXED)
                         self.drawingDone.emit()
                         event.accept()
                         return 
@@ -220,17 +221,17 @@ class Shape(QGraphicsObject):
             if self.shape_type == "polygon" and self.mode == Shape.ShapeMode.CREATE and len(self.vertices.vertices) > 1:
                 self.ungrabMouse()
                 self.is_closed_path = True
-
+                self.set_mode(Shape.ShapeMode.FIXED)
                 self.drawingDone.emit()
-                super(Shape, self).mousePressEvent(event)
+                event.accept()
 
 
     def mouseDoubleClickEvent(self, event: QGraphicsSceneMouseEvent):
-        if self.contains(event.pos()):
-            self.set_mode(Shape.ShapeMode.EDIT)
-        else:
-            event.ignore()
-        super(Shape, self).mouseDoubleClickEvent(event)
+        if self.mode == Shape.ShapeMode.FIXED or self.mode == Shape.ShapeMode.EDIT:
+            self.labelRequested.emit()
+            event.accept()
+            return
+        super().mouseDoubleClickEvent(event)
 
     @Slot(QGraphicsSceneMouseEvent)
     def mouseReleaseEvent(self, event: QGraphicsSceneMouseEvent) -> None:

--- a/taplt/ui/shape.py
+++ b/taplt/ui/shape.py
@@ -21,6 +21,7 @@ class Shape(QGraphicsObject):
     mode_changed = Signal(int)
     deleted = Signal()
     drawingDone = Signal()
+    sChange = Signal(int)
     sIllegalCircleOnBorder = Signal()
     labelRequested = Signal()
 

--- a/test/shape_test.py
+++ b/test/shape_test.py
@@ -4,7 +4,8 @@ from PySide6.QtWidgets import QApplication, QGraphicsScene, QGraphicsSceneMouseE
 from PySide6.QtCore import QSize, QPointF, QEvent
 from PySide6.QtGui import Qt
 from taplt.ui.shape import Shape
-
+from taplt.ui.annotation_group import AnnotationGroup
+from unittest import mock
 
 app = QApplication.instance() or QApplication(sys.argv)
 
@@ -45,3 +46,48 @@ def test_circle_not_closed_after_1_point():
     scene.addItem(shape)
     shape.mousePressEvent(make_mouse_event(QPointF(100, 200)))
     assert shape.is_closed_path == False
+
+def finish_shape(group: AnnotationGroup, p1: QPointF, p2: QPointF):
+    group.create_shape()
+    shape = group.temp_shape
+    shape.mousePressEvent(make_mouse_event(p1))
+    shape.mousePressEvent(make_mouse_event(p2))
+    return shape
+def test_shape_in_pending_before_labeling():
+    scene = QGraphicsScene()
+    group = AnnotationGroup()
+    scene.addItem(group)
+    group.set_type(Shape.ShapeType.RECTANGLE)
+
+    shape1 = finish_shape(group, QPointF(0,0), QPointF(50,50))
+    assert len(group.pending_shapes) == 1
+    assert shape1.label is None 
+
+    shape2 = finish_shape(group, QPointF(100, 100), QPointF(150,150))
+    assert len(group.pending_shapes) == 2
+    assert shape2.label is None
+
+    assert all(s.label is None for s in group.pending_shapes)
+
+def test_pending_shapes_get_same_label(monkeypatch):
+    scene = QGraphicsScene()
+    group = AnnotationGroup()
+    scene.addItem(group)
+    group.set_type(Shape.ShapeType.RECTANGLE)
+
+    shape1 = finish_shape(group, QPointF(0, 0), QPointF(50, 50))
+    shape2 = finish_shape(group, QPointF(100, 100), QPointF(150, 150))
+
+    class FakeDialog:
+        def __init__ (self, *args, **kwargs):
+            pass
+        def exec(self):
+            pass
+        result = "Mitochondrien"
+
+    monkeypatch.setattr('taplt.ui.annotation_group.NewLabelDialog', FakeDialog)
+    group.set_pending_label()
+
+    assert shape1.label == "Mitochondrien"
+    assert shape2.label == "Mitochondrien"
+    assert group.pending_shapes == []


### PR DESCRIPTION
resolves #35 und #43 

### Changes
- Annotationen werden erst durch `pending_shapes` in `annotation_group.py` gesammelt
- Das Drücken der Enter-Taste öffnet das Label-Popup und gibt alle bisher nicht-gelabelten Annotation dasselbe Label
- Wenn eine Annotation fertig ist wechselt `Shape` in den `FIXED`-mode, damit es nicht weiterhin im Zeichenmodus bleibt, sondern für das Labeling ausgewählt werden kann
- Shapes können jetzt auch normal ohne Fehlermeldungen oder Tool Blockierungen gelöscht werden -> `None` check in `annotation_tree.py`
- `mouseDoubleClickEvent` wurde auf die ursprüngliche Funktion zurückgesetzt (Verschieben von Formen)
- Ich habe noch Fehlermeldungen bemerkt, wenn man shapes löscht bevor man dene ein label gibt. Fix: Die gelöschte shapes werden auch aus `pending_shapes` entfernt