### PR TITLE
add font size settings

### DIFF
--- a/taplt/ui/dialogs.py
+++ b/taplt/ui/dialogs.py
@@ -1,5 +1,5 @@
 from PySide6.QtWidgets import QMessageBox, QPushButton, QStyle, QDialog, QTextEdit, QDialogButtonBox, QVBoxLayout, \
-    QLineEdit, QLabel, QFrame, QListWidgetItem, QListWidget, QHBoxLayout, QFileDialog
+    QLineEdit, QLabel, QFrame, QListWidgetItem, QListWidget, QHBoxLayout, QFileDialog, QComboBox
 from PySide6.QtCore import QSize, QPoint
 from PySide6.QtGui import Qt, QColor
 
@@ -422,8 +422,19 @@ class SettingDialog(QDialog):
 
         self.header = QLabel("Enter your preferences")
         self.header.setStyleSheet(f"font: bold {BASE_FONT_SIZE + 2}px")
-        self.preferences = SettingList(settings)
+        boolean_settings = [s for s in settings if s[0] != "Font size"]
+        self.preferences = SettingList(boolean_settings)
         self.settings = list()
+
+        # font size selection
+        self.font_size_label = QLabel("Font size")
+        self.font_size_combo = QComboBox()
+        self.font_size_combo.addItems(["small", "medium", "large"])
+        font_setting = next((s[1] for s in settings if s[0] == "Font size"), "medium")
+        idx = self.font_size_combo.findText(str(font_setting))
+        if idx >= 0:
+            self.font_size_combo.setCurrentIndex(idx)
+
 
         # Accept & cancel buttons
         self.confirmation = QDialogButtonBox(
@@ -433,6 +444,8 @@ class SettingDialog(QDialog):
 
         self.layout().addWidget(self.header)
         self.layout().addWidget(self.preferences)
+        self.layout().addWidget(self.font_size_label)
+        self.layout().addWidget(self.font_size_combo)
         self.layout().addWidget(self.confirmation)
 
     def save_settings(self):
@@ -441,6 +454,8 @@ class SettingDialog(QDialog):
             key = item.text()
             value = True if item.checkState() == Qt.CheckState.Checked else False
             self.settings.append((key, value))
+
+        self.settings.append(("Font size", self.font_size_combo.currentText()))
         self.close()
 
 

--- a/taplt/ui/main_window.py
+++ b/taplt/ui/main_window.py
@@ -1,5 +1,6 @@
 from PySide6.QtWidgets import *
 from PySide6.QtCore import *
+from PySide6.QtGui import QFont
 
 from pathlib import Path
 from dataclasses import dataclass
@@ -15,6 +16,7 @@ from taplt.ui.annotation_tree import AnnotationTree
 from taplt.ui.welcome_screen import WelcomeScreen
 from taplt.utils.qt import colormap_rgb, get_icon
 from taplt.utils.project_structure import check_environment, Structure
+from taplt.utils.stylesheets import TAB_STYLESHEET, FONT_SMALL, FONT_MEDIUM, FONT_LARGE
 from taplt.macros.macros import Macros
 from taplt.macros.macros_dialogs import PreviewDatabaseDialog
 
@@ -178,6 +180,7 @@ class LabelingMainWindow(QMainWindow):
 
     def apply_settings(self, settings: list):
         """applies the settings"""
+        font_size = None
         for setting in settings:
             if setting[0] == "Autosave on file change":
                 self.autoSave = setting[1]
@@ -186,6 +189,25 @@ class LabelingMainWindow(QMainWindow):
                 self.sRequestUpdate.emit(self.img_idx)
             elif setting[0] == "Display patient name":
                 self.file_display.patient_label.setVisible(setting[1])
+            elif setting[0] == "Font size":
+                value = str(setting[1]).lower()
+                if value == "small":
+                    font_size = FONT_SMALL
+                elif value == "large":
+                    font_size = FONT_LARGE
+                else:
+                    font_size = FONT_MEDIUM
+
+        if font_size is not None:
+            font = QFont()
+            font.setPointSize(font_size)
+            QApplication.instance().setFont(font)
+            self.file_list.tab.setStyleSheet(TAB_STYLESHEET.format(tab_size=font_size))
+            self.file_list.search_field.setFont(font)
+            self.file_list.image_list.setFont(font)
+            self.file_list.wsi_list.setFont(font)
+            self.labels_list.label_list.setFont(font)
+
         self.sUpdateSettings.emit(settings)
 
     def change_detected(self, change: int):

--- a/taplt/ui/main_window.py
+++ b/taplt/ui/main_window.py
@@ -207,6 +207,10 @@ class LabelingMainWindow(QMainWindow):
             self.file_list.image_list.setFont(font)
             self.file_list.wsi_list.setFont(font)
             self.labels_list.label_list.setFont(font)
+            self.toolBar.setFont(font)
+
+            for button in self.toolBar.findChildren(QToolButton):
+                button.setFont(font)
 
         self.sUpdateSettings.emit(settings)
 

--- a/taplt/utils/database.py
+++ b/taplt/utils/database.py
@@ -262,11 +262,10 @@ class SQLiteDatabase(QObject):
         return self.cursor.fetchone()[0]
 
     def get_settings(self):
-        """retrieves the values stored in the settings file"""
+        """retrieves the values stored in the settings file, using default values if no value is stored yet"""
         settings = list()
-        for key in self.settings.allKeys():
-            value = self.settings.value(key)
-            tooltip = get_tooltip(key)
+        for key, default_value, tooltip in SETTINGS:
+            value = self.settings.value(key, default_value)
             settings.append((key, value, tooltip))
         return settings
 

--- a/taplt/utils/settings.py
+++ b/taplt/utils/settings.py
@@ -12,7 +12,12 @@ s3 = ("Display patient name",
       False,
       "Shows the patient name at the bottom of the image")
 
-SETTINGS = [s1, s2, s3]
+s4 = ("Font size",
+      "medium",
+      "Font size for the toolbar, menu, and side panels (small/medium/large)")
+
+
+SETTINGS = [s1, s2, s3, s4]
 
 
 def get_tooltip(setting: str):

--- a/taplt/utils/stylesheets.py
+++ b/taplt/utils/stylesheets.py
@@ -1,4 +1,8 @@
-BASE_FONT_SIZE = 11
+FONT_SMALL = 9
+FONT_MEDIUM = 11
+FONT_LARGE = 13
+
+BASE_FONT_SIZE = FONT_MEDIUM
 
 BUTTON_STYLESHEET = """QPushButton {{
                        background-color: lightgray;


### PR DESCRIPTION
Resolves #52 
Die Schriftgröße ist jetzt über die Einstellungen anpassbar.

## Änderungen
- **`settings.py`**: Neue Einstellung für die Schriftgröße mit Standard "medium"
- **`dialogs.py`**: Dropdown in den Einstellungen mit den Optionen "small", "medium" und "large"
- **`main_window.py`**: Gewählte Schriftgröße wird auf Toolbar, Seitenpanels und Menüs angewendet
- **`database.py`**: Einstellungen speichern
- **`stylesheets.py`**: Neue Font-Konstanten für kleine, mittlere und große Schriftgrößen definiert

## Hinweis
- Bei Schriftgröße "large" wird der Rectangle-Button nicht mehr ganz angezeigt -> Rectangle wird zu Rec...gle
- Beim Schließen und erneut öffnen der Anwendung wird zwar die letzte Schriftgröße in den Einstellungen gespeichert, aber nicht angewendet -> im Moment muss man sie in den Einstellungen erneut speichern 