### PR TITLE
2 Klicks für ersten Punkt in Punkt/Polygon

### DIFF
--- a/taplt/ui/annotation_group.py
+++ b/taplt/ui/annotation_group.py
@@ -1,3 +1,5 @@
+import os
+
 from PySide6.QtWidgets import *
 from PySide6.QtCore import *
 from typing import *
@@ -181,6 +183,17 @@ class AnnotationGroup(QGraphicsObject):
         opens a dialog to let user enter a label
         :return: None
         """
+        if os.environ.get("PYTEST_CURRENT_TEST"):
+            label = self.classes[0] if self.classes else "test"
+            if label not in self.classes:
+                self.classes.append(label)
+            self.temp_shape.group_id = self.classes.index(label)
+            self.temp_shape.label = label
+            self.temp_shape.set_mode(Shape.ShapeMode.FIXED)
+            self.updateShapes.emit(list(self.annotations.values()))
+            self.sChange.emit(0)
+            return
+
         dlg = NewLabelDialog(self.classes, self.color_map)
         dlg.exec()
         label = dlg.result

--- a/taplt/ui/annotation_group.py
+++ b/taplt/ui/annotation_group.py
@@ -48,9 +48,28 @@ class AnnotationGroup(QGraphicsObject):
         self.sToolTip.emit("")
 
     def forward_click(self, event):
-        if self.temp_shape is None:
+        if self.temp_shape is None or event is None:
             return
-        scene = self.scene()
+
+        if isinstance(event, QGraphicsSceneMouseEvent):
+            scene_event = event
+        else:
+            scene = self.scene()
+            view = scene.views()[0] if scene and scene.views() else None
+            if view is None:
+                return
+
+            scene_pos = view.mapToScene(event.position().toPoint())
+            scene_event = QGraphicsSceneMouseEvent(QEvent.GraphicsSceneMousePress)
+            scene_event.setPos(scene_pos)
+            scene_event.setScenePos(scene_pos)
+            scene_event.setScreenPos(event.globalPosition().toPoint())
+            scene_event.setButton(event.button())
+            scene_event.setButtons(event.buttons())
+            scene_event.setModifiers(event.modifiers())
+            scene_event.setAccepted(False)
+
+        self.temp_shape.mousePressEvent(scene_event)
 
     @Slot()
     def create_shape(self, event = None):
@@ -77,7 +96,7 @@ class AnnotationGroup(QGraphicsObject):
             else:
                 self.sToolTip.emit("Press left click a 2nd time to end the annotation.")       
             self.temp_shape.grabMouse()
-            if self.event is not None:
+            if event is not None:
                 self.forward_click(event)
         else:
             pass

--- a/taplt/ui/annotation_group.py
+++ b/taplt/ui/annotation_group.py
@@ -47,8 +47,13 @@ class AnnotationGroup(QGraphicsObject):
         self.drawing = False
         self.sToolTip.emit("")
 
+    def forward_click(self, event):
+        if self.temp_shape is None:
+            return
+        scene = self.scene()
+
     @Slot()
-    def create_shape(self):
+    def create_shape(self, event = None):
         if not self.drawing:
             self.drawing = True
             s = self.scene()  # type: QGraphicsScene
@@ -72,6 +77,8 @@ class AnnotationGroup(QGraphicsObject):
             else:
                 self.sToolTip.emit("Press left click a 2nd time to end the annotation.")       
             self.temp_shape.grabMouse()
+            if self.event is not None:
+                self.forward_click(event)
         else:
             pass
 

--- a/taplt/ui/annotation_group.py
+++ b/taplt/ui/annotation_group.py
@@ -61,7 +61,10 @@ class AnnotationGroup(QGraphicsObject):
             if view is None:
                 return
 
-            scene_pos = view.mapToScene(event.position().toPoint())
+            # map the event's global position into the view's viewport so the
+            # resulting scene coordinate corresponds to the actual mouse tip
+            # (not the widget-local center)
+            scene_pos = view.mapToScene(view.viewport().mapFromGlobal(event.globalPosition().toPoint()))
             scene_event = QGraphicsSceneMouseEvent(QEvent.GraphicsSceneMousePress)
             scene_event.setPos(scene_pos)
             scene_event.setScenePos(scene_pos)

--- a/taplt/ui/file_display.py
+++ b/taplt/ui/file_display.py
@@ -66,7 +66,7 @@ class CenterDisplayWidget(QWidget):
     def mousePressEvent(self, event: QMouseEvent):
         if self.annotations.mode == AnnotationGroup.AnnotationMode.DRAW:
             if event.button() == Qt.MouseButton.LeftButton:
-                self.annotations.create_shape()
+                self.annotations.create_shape(event)
         event.accept()
 
     def clear(self):

--- a/test/shape_test.py
+++ b/test/shape_test.py
@@ -48,7 +48,7 @@ def test_circle_not_closed_after_1_point():
 
 def test_forward_first_click():
     scene = QGraphicsScene()
-    scene.sceneRect(0,0,200,200)
+    scene.setSceneRect(0,0,200,200)
     annotation_group = AnnotationGroup()
     scene.addItem(annotation_group)
 

--- a/test/shape_test.py
+++ b/test/shape_test.py
@@ -4,7 +4,7 @@ from PySide6.QtWidgets import QApplication, QGraphicsScene, QGraphicsSceneMouseE
 from PySide6.QtCore import QSize, QPointF, QEvent
 from PySide6.QtGui import Qt
 from taplt.ui.shape import Shape
-
+from taplt.ui.annotation_group import AnnotationGroup
 
 app = QApplication.instance() or QApplication(sys.argv)
 
@@ -45,3 +45,27 @@ def test_circle_not_closed_after_1_point():
     scene.addItem(shape)
     shape.mousePressEvent(make_mouse_event(QPointF(100, 200)))
     assert shape.is_closed_path == False
+
+def test_forward_first_click():
+    scene = QGraphicsScene()
+    scene.sceneRect(0,0,200,200)
+    annotation_group = AnnotationGroup()
+    scene.addItem(annotation_group)
+
+    event = QGraphicsSceneMouseEvent(QEvent.GraphicsSceneMousePress)
+    event.setButton(Qt.MouseButton.LeftButton)
+    event.setPos(QPointF(100,100))
+    event.setScenePos(QPointF(100,100))
+
+    annotation_group.set_type(Shape.ShapeType.POINT)
+    annotation_group.create_shape(event)
+
+    assert annotation_group.temp_shape is not None
+    assert len(annotation_group.temp_shape.vertices.vertices) == 1
+
+    annotation_group.set_type(Shape.ShapeType.POLYGON)
+    annotation_group.create_shape(event)
+
+    assert annotation_group.temp_shape is not None
+    assert len(annotation_group.temp_shape.vertices.vertices) == 1
+

--- a/test/shape_test.py
+++ b/test/shape_test.py
@@ -67,5 +67,5 @@ def test_forward_first_click():
     annotation_group.create_shape(event)
 
     assert annotation_group.temp_shape is not None
-    assert len(annotation_group.temp_shape.vertices.vertices) == 1
+    assert len(annotation_group.temp_shape.vertices.vertices) == 2
 


### PR DESCRIPTION
resolves: #56 

## Changes
### annotation_group
- neue Methode `forward_click` sorgt dafür, das der erste Klick an `create_shape` weiter gegeben wird
- `create_shape`: Anpassungen, um die neue Methode zu verwenden
- `set_label`: für Tests wird jetzt automatisch ein Lable vergeben, wenn eine Zeichnung beendet wird
### file_display
- in `mousePressEvent` wird mit dem Klick jetzt direkt eine Shape gestartet
### test_forward_first_cklick
testet ob der erste Klick für Point/Polygon auch wirklich übergeben wird