### PR TITLE
label popup for wsi 

### DIFF
--- a/taplt/media_viewing_widgets/widgets/slide_viewer.py
+++ b/taplt/media_viewing_widgets/widgets/slide_viewer.py
@@ -17,6 +17,7 @@ class SlideView(QGraphicsView):
     sendPixmap = Signal(QGraphicsPixmapItem)
     pixmapFinished = Signal()
     sZoomChanged = Signal(float)
+    sEnterPressed = Signal()
 
     def __init__(self, *args):
         super().__init__(*args)
@@ -395,6 +396,9 @@ class SlideView(QGraphicsView):
         self.pixmap_compensation = QPointF(0, 0)
         self.updating = False
         self.zoom_finished = True
+    def keyPressEvent(self, event) -> None:
+        if event.key() == Qt.Key.Key_Return or event.key() == Qt.Key.Key_Enter:
+            self.sEnterPressed.emit()
 
 
 class ImageBlockWrapper(QThread):

--- a/taplt/ui/file_display.py
+++ b/taplt/ui/file_display.py
@@ -65,6 +65,7 @@ class CenterDisplayWidget(QWidget):
         self.layout.addWidget(self.patient_label)
 
         self.image_viewer.sEnterPressed.connect(self.on_enter_pressed)
+        self.slide_viewer.sEnterPressed.connect(self.on_enter_pressed)
 
         self.slide_viewer.sZoomChanged.connect(self.sZoomChanged)
     


### PR DESCRIPTION
resolves #64 
Drücken der Enter-Taste in wsi öffnet jetzt auch den label popup für pending shapes, genauso wie für normale Bilder. 
