### PR TITLE
Undo/Redo

### DIFF
--- a/taplt/ui/annotation_group.py
+++ b/taplt/ui/annotation_group.py
@@ -39,6 +39,8 @@ class AnnotationGroup(QGraphicsObject):
         self.shapeType = Shape.ShapeType.POLYGON
         self.drawing = False
         self.pending_shapes = []
+        self.undo_stack = []
+        self.redo_stack = []
 
     def boundingRect(self):
         return self.childrenBoundingRect()
@@ -135,17 +137,22 @@ class AnnotationGroup(QGraphicsObject):
             shape.deleted.connect(lambda: self.remove_shapes(shape))
             shape.mode_changed.connect(self.shape_mode_changed)
             shape.labelRequested.connect(self.set_pending_label)
-            shape.drawingDone.connect(lambda s=shape: self.pending_shapes.append(s))
+            if shape not in self.undo_stack:
+                shape.drawingDone.connect(lambda s=shape: self.add_to_history(s))
             shape.drawingDone.connect(self.set_drawing_to_false)
             shape.sChange.connect(self.sChange.emit)
             self.update()
+    
+    def add_to_history(self, shape):
+        self.undo_stack.append(shape)
+        self.redo_stack.clear()
 
     def deselect_all(self):
         """deselects all shapes"""
         for shape in self.annotations.values():
             shape.setSelected(False)
 
-    def remove_shapes(self, shapes: Union[Shape, List[Shape]]):
+    def remove_shapes(self, shapes: Union[Shape, List[Shape]], show_dialog=True):
         """
         Remove shapes from the group and scene if connected to one.
         :param shapes: a shape or list of shapes
@@ -154,10 +161,11 @@ class AnnotationGroup(QGraphicsObject):
         if shapes is None:
             return
         if isinstance(shapes, Shape):
-            dlg = DeleteShapeMessageBox(shapes.label)
-            dlg.exec()
-            if dlg.result() != QMessageBox.Ok:
-                return
+            if show_dialog:
+                dlg = DeleteShapeMessageBox(shapes.label)
+                dlg.exec()
+                if dlg.result() != QMessageBox.Ok:
+                    return
             shapes = [shapes]
             self.sChange.emit(1)
         ids_to_remove = []
@@ -255,7 +263,21 @@ class AnnotationGroup(QGraphicsObject):
         for lbl in current_labels:
             self.add_shapes(lbl)
         self.updateShapes.emit(current_labels)
-
+    
+    def undo(self):
+        if not self.undo_stack:
+            return
+        
+        shape = self.undo_stack.pop()
+        self.redo_stack.append(shape)
+        self.remove_shapes(shape, show_dialog=False)
+    
+    def redo(self):
+        if not self.redo_stack:
+            return
+        shape = self.redo_stack.pop()
+        self.add_shapes(shape)
+        self.undo_stack.append(shape)
 
 if __name__ == '__main__':
     from PySide6.QtGui import *

--- a/taplt/ui/annotation_group.py
+++ b/taplt/ui/annotation_group.py
@@ -137,8 +137,7 @@ class AnnotationGroup(QGraphicsObject):
             shape.deleted.connect(lambda: self.remove_shapes(shape))
             shape.mode_changed.connect(self.shape_mode_changed)
             shape.labelRequested.connect(self.set_pending_label)
-            if shape not in self.undo_stack:
-                shape.drawingDone.connect(lambda s=shape: self.add_to_history(s))
+            shape.drawingDone.connect(lambda s=shape: self.add_to_history(s))
             shape.drawingDone.connect(lambda s=shape: self.pending_shapes.append(s))
             shape.drawingDone.connect(self.set_drawing_to_false)
             shape.sChange.connect(self.sChange.emit)
@@ -157,7 +156,7 @@ class AnnotationGroup(QGraphicsObject):
         for shape in self.annotations.values():
             shape.setSelected(False)
 
-    def remove_shapes(self, shapes: Union[Shape, List[Shape]], show_dialog=True):
+    def remove_shapes(self, shapes: Union[Shape, List[Shape]]):
         """
         Remove shapes from the group and scene if connected to one.
         :param shapes: a shape or list of shapes
@@ -166,11 +165,10 @@ class AnnotationGroup(QGraphicsObject):
         if shapes is None:
             return
         if isinstance(shapes, Shape):
-            if show_dialog:
-                dlg = DeleteShapeMessageBox(shapes.label)
-                dlg.exec()
-                if dlg.result() != QMessageBox.Ok:
-                    return
+            dlg = DeleteShapeMessageBox(shapes.label)
+            dlg.exec()
+            if dlg.result() != QMessageBox.Ok:
+                return
             shapes = [shapes]
             self.sChange.emit(1)
         ids_to_remove = []
@@ -184,9 +182,7 @@ class AnnotationGroup(QGraphicsObject):
             if shape not in shapes:
                 updated_pending_shapes.append(shape)
         self.pending_shapes = updated_pending_shapes
-        self.updateShapes.emit(
-            [s for s in self.annotations.values() if s.isVisible()]
-        )
+        self.updateShapes.emit(list(self.annotations.values()))
 
     def clear(self):
         """
@@ -247,7 +243,7 @@ class AnnotationGroup(QGraphicsObject):
             
             self.pending_shapes.clear()
             self.updateShapes.emit(
-                [s for s in self.annotations.values() if s.isVisible()]
+                list(self.annotations.values())
             )
             self.sChange.emit(0)
 
@@ -286,7 +282,7 @@ class AnnotationGroup(QGraphicsObject):
             self.pending_shapes.remove(shape)
         self.redo_stack.append(shape)
         self.updateShapes.emit(
-            [s for s in self.annotations.values() if s.isVisible()]
+            list(self.annotations.values())
         )
     
     def redo(self):
@@ -298,7 +294,7 @@ class AnnotationGroup(QGraphicsObject):
         if shape.label is None:
             self.pending_shapes.append(shape)
         self.updateShapes.emit(
-            [s for s in self.annotations.values() if s.isVisible()]
+            list(self.annotations.values())
         )
 
 if __name__ == '__main__':

--- a/taplt/ui/annotation_group.py
+++ b/taplt/ui/annotation_group.py
@@ -280,6 +280,9 @@ class AnnotationGroup(QGraphicsObject):
         
         if shape in self.pending_shapes:
             self.pending_shapes.remove(shape)
+        
+        if shape in self.pending_shapes:
+            self.pending_shapes.remove(shape)
         self.redo_stack.append(shape)
         self.updateShapes.emit(
             list(self.annotations.values())

--- a/taplt/ui/annotation_group.py
+++ b/taplt/ui/annotation_group.py
@@ -139,12 +139,17 @@ class AnnotationGroup(QGraphicsObject):
             shape.labelRequested.connect(self.set_pending_label)
             if shape not in self.undo_stack:
                 shape.drawingDone.connect(lambda s=shape: self.add_to_history(s))
+            shape.drawingDone.connect(lambda s=shape: self.pending_shapes.append(s))
             shape.drawingDone.connect(self.set_drawing_to_false)
             shape.sChange.connect(self.sChange.emit)
             self.update()
     
     def add_to_history(self, shape):
         self.undo_stack.append(shape)
+        self.redo_stack.clear()
+    
+    def clear_history(self):
+        self.undo_stack.clear()
         self.redo_stack.clear()
 
     def deselect_all(self):
@@ -179,7 +184,9 @@ class AnnotationGroup(QGraphicsObject):
             if shape not in shapes:
                 updated_pending_shapes.append(shape)
         self.pending_shapes = updated_pending_shapes
-        self.updateShapes.emit(list(self.annotations.values()))
+        self.updateShapes.emit(
+            [s for s in self.annotations.values() if s.isVisible()]
+        )
 
     def clear(self):
         """
@@ -239,7 +246,9 @@ class AnnotationGroup(QGraphicsObject):
                 shape.set_mode(Shape.ShapeMode.FIXED)
             
             self.pending_shapes.clear()
-            self.updateShapes.emit(list(self.annotations.values()))
+            self.updateShapes.emit(
+                [s for s in self.annotations.values() if s.isVisible()]
+            )
             self.sChange.emit(0)
 
         # if user entered no label, keep pending shapes
@@ -269,15 +278,28 @@ class AnnotationGroup(QGraphicsObject):
             return
         
         shape = self.undo_stack.pop()
+
+        if shape in self.annotations.values():
+            shape.setVisible(False)
+        
+        if shape in self.pending_shapes:
+            self.pending_shapes.remove(shape)
         self.redo_stack.append(shape)
-        self.remove_shapes(shape, show_dialog=False)
+        self.updateShapes.emit(
+            [s for s in self.annotations.values() if s.isVisible()]
+        )
     
     def redo(self):
         if not self.redo_stack:
             return
         shape = self.redo_stack.pop()
-        self.add_shapes(shape)
+        shape.setVisible(True)
         self.undo_stack.append(shape)
+        if shape.label is None:
+            self.pending_shapes.append(shape)
+        self.updateShapes.emit(
+            [s for s in self.annotations.values() if s.isVisible()]
+        )
 
 if __name__ == '__main__':
     from PySide6.QtGui import *

--- a/taplt/ui/main_window.py
+++ b/taplt/ui/main_window.py
@@ -414,9 +414,13 @@ class LabelingMainWindow(QMainWindow):
 
     def save_to_database(self):
         """stores the current state of the image to the database"""
-        annotations = list(self.file_display.annotations.annotations.values())
+        annotations = [
+            shape for shape in self.file_display.annotations.annotations.values()
+            if shape.isVisible()
+        ]    
         self.changes.clear()
         self.sSaveToDatabase.emit(annotations, self.img_idx)
+        self.file_display.annotations.clear_history()
 
     def set_no_files_screen(self, b: bool):
         """ either hides the default label or the image display"""

--- a/taplt/ui/main_window.py
+++ b/taplt/ui/main_window.py
@@ -1,6 +1,6 @@
 from PySide6.QtWidgets import *
 from PySide6.QtCore import *
-from PySide6.QtGui import QFont, QIcon
+from PySide6.QtGui import QAction, QFont, QKeySequence, QIcon
 
 from pathlib import Path
 from dataclasses import dataclass
@@ -185,6 +185,16 @@ class LabelingMainWindow(QMainWindow):
         self.menubar.sExampleProject.connect(self.macros.example_project)
 
         self.file_list.sFilesDropped.connect(self.import_dropped_files)
+
+        undo_action = QAction(self)
+        undo_action.setShortcut(QKeySequence.StandardKey.Undo) # Ctrl+Z
+        undo_action.triggered.connect(self.file_display.annotations.undo)
+        self.addAction(undo_action)
+
+        redo_action = QAction(self)
+        redo_action.setShortcut(QKeySequence.StandardKey.Redo) # Ctrl+Y
+        redo_action.triggered.connect(self.file_display.annotations.redo)
+        self.addAction(redo_action)
 
     def show_duplicate_warning(self, filename: str):
         QMessageBox.warning(self, "Duplicate File",

--- a/taplt/ui/main_window.py
+++ b/taplt/ui/main_window.py
@@ -187,12 +187,12 @@ class LabelingMainWindow(QMainWindow):
         self.file_list.sFilesDropped.connect(self.import_dropped_files)
 
         undo_action = QAction(self)
-        undo_action.setShortcut(QKeySequence.StandardKey.Undo) # Ctrl+Z
+        undo_action.setShortcut(QKeySequence("Ctrl+Z"))
         undo_action.triggered.connect(self.file_display.annotations.undo)
         self.addAction(undo_action)
 
         redo_action = QAction(self)
-        redo_action.setShortcut(QKeySequence.StandardKey.Redo) # Ctrl+Y
+        redo_action.setShortcut(QKeySequence("Ctrl+Y"))
         redo_action.triggered.connect(self.file_display.annotations.redo)
         self.addAction(redo_action)
 

--- a/test/shape_test.py
+++ b/test/shape_test.py
@@ -114,3 +114,34 @@ def test_pending_shapes_get_same_label(monkeypatch):
     assert shape1.label == "Mitochondrien"
     assert shape2.label == "Mitochondrien"
     assert group.pending_shapes == []
+
+def test_undo():
+    scene = QGraphicsScene()
+    group = AnnotationGroup()
+    scene.addItem(group)
+    group.set_type(Shape.ShapeType.RECTANGLE)
+
+    shape1 = finish_shape(group, QPointF(0, 0), QPointF(50, 50))
+    shape2 = finish_shape(group, QPointF(110, 120), QPointF(150, 250))
+
+    group.undo()
+
+    assert shape1.isVisible()
+    assert not shape2.isVisible()
+    assert shape2 not in group.pending_shapes
+    assert shape2 in group.redo_stack
+
+
+def test_redo():
+    scene = QGraphicsScene()
+    group = AnnotationGroup()
+    scene.addItem(group)
+    group.set_type(Shape.ShapeType.CIRCLE)
+
+    shape = finish_shape(group, QPointF(20, 220), QPointF(123, 321))
+
+    group.undo()
+    group.redo()
+
+    assert shape.isVisible()
+    assert shape in group.pending_shapes


### PR DESCRIPTION
resolves #62 

## Changes:

`annotation_group.py:`
- Undo entfernt die zuletzt erstellt Annotation aus der sichtbaren Ansicht
- Redo stellt die zuletzt entfernte Annotation wieder her
- Redo fügt ungelabelte Annotationen wieder zu `pending_shapes` hinzu, damit sie auch neu beschriftet werden können
- `clear_history` ergänzt, um den undo und redo Verlauf nach dem Speichern wieder zurückzusetzen

`main_window.py:`

- keyboard shortcut: Ctrl+Z for undo, Ctrl+Y for redo
- Beim Speichern werden nur sichtbare Annotationen an die Datenbank übergeben

### Testen:
- Undo und redo bei mehreren Annotation verwenden
- Ungelabelte Annotationen nach einem Redo erneut beschriften speichern und überprüfen, dass nur sichtbare Annotationen gespeichert werden 
