### PR TITLE
Dynamische Toolbar-Breite

### DIFF
--- a/taplt/ui/main_window.py
+++ b/taplt/ui/main_window.py
@@ -241,6 +241,7 @@ class LabelingMainWindow(QMainWindow):
 
             for button in self.toolBar.findChildren(QToolButton):
                 button.setFont(font)
+                self.toolBar.update_button_sizes()
 
         self.sUpdateSettings.emit(settings)
 

--- a/taplt/ui/toolbar.py
+++ b/taplt/ui/toolbar.py
@@ -21,7 +21,6 @@ class Toolbar(QWidget):
 
         self.setLayout(layout)
         self.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
-        self._button_width = 80
 
         self.actionsDict = {}  # This is a lookup table to match the buttons to the numbers they got added
 
@@ -60,15 +59,14 @@ class Toolbar(QWidget):
         [x.setChecked(False) for x in self.button_group.buttons() if x != btn]
 
     def update_button_sizes(self):
-        """Update toolbar and button widths based on the longest button label."""
-        max_width = 40
+        """Update toolbar and button sizes based on the buttons' size hints."""
+        max_width = 0
 
         for button in self.button_group.buttons():
-            text = button.text().replace("\n", " ")
+            max_width = max(max_width, button.sizeHint().width())
 
-            width = button.fontMetrics().horizontalAdvance(text) + 15
-
-            max_width = max(max_width, width)
+        if max_width == 0: # No buttons present, avoid setting width to 0
+            return
 
         self._button_width = max_width
 

--- a/taplt/ui/toolbar.py
+++ b/taplt/ui/toolbar.py
@@ -20,8 +20,8 @@ class Toolbar(QWidget):
         layout.setSpacing(4)
 
         self.setLayout(layout)
-        self.setFixedWidth(80)
         self.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        self._button_width = 80
 
         self.actionsDict = {}  # This is a lookup table to match the buttons to the numbers they got added
 
@@ -59,6 +59,24 @@ class Toolbar(QWidget):
     def exclusive_optional(self, btn: QToolButton):
         [x.setChecked(False) for x in self.button_group.buttons() if x != btn]
 
+    def update_button_sizes(self):
+        """Update toolbar and button widths based on the longest button label."""
+        max_width = 40
+
+        for button in self.button_group.buttons():
+            text = button.text().replace("\n", " ")
+
+            width = button.fontMetrics().horizontalAdvance(text) + 15
+
+            max_width = max(max_width, width)
+
+        self._button_width = max_width
+
+        self.setFixedWidth(self._button_width)
+
+        for button in self.button_group.buttons():
+            button.setFixedSize(self._button_width, 70)
+
     def addAction(self, action: Action):
         r"""Because I want a physical button in the toolbar, i need to create a widget"""
         """if isinstance(action, QWidgetAction):
@@ -70,8 +88,6 @@ class Toolbar(QWidget):
             self.button_group.addButton(btn)
         btn.setDefaultAction(action)
         btn.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextUnderIcon)
-        btn.setMinimumSize(80, 70)
-        btn.setMaximumSize(80, 70)
         btn.setIconSize(QSize(24, 24))
         btn.setStyleSheet("""
             QToolButton {
@@ -84,6 +100,7 @@ class Toolbar(QWidget):
         """)
 
         self.layout().addWidget(btn)
+        self.update_button_sizes()
 
         """action_text = action.text().replace('\n', '')
         self.actionsDict[action_text] = len(self.actionsDict)"""


### PR DESCRIPTION
Resolves #66 

Die Toolbar-Breite passt sich jetzt an die verwendete Schriftgröße an und nach einer Änderung dieser, wird die Breite neu berechnet. 

### Änderungen
`taplt/ui/toolbar.py`
- entfernen der festen Toolbar-Breite von 80px
- neue Methode update_button_sizes() hinzugefügt
- Breite der Toolbar wird nun anhand der von Qt berechneten Button-Größen (`sizeHint()`) bestimmt

`taplt/ui/main_window.py`
- aufrufen von `update_button_sizes()` in `apply_settings()`
- Toolbar-Größe wird bei Änderungen der Schriftgröße neu berechnet

### Ergebnis
- keine abgeschnittenen Toolbar-Beschriftungen mehr bei großen Schriftgrößen (z. B. `Rectangle`)
- kompaktere Toolbar bei kleinen Schriftgrößen

### Vorher (Large)
<img width="1920" height="1008" alt="large_vorher" src="https://github.com/user-attachments/assets/390001f2-3dd8-4f4e-97c6-34f0e0e2c0df" />

### Nachher (Large)
<img width="1920" height="1008" alt="large_nachher" src="https://github.com/user-attachments/assets/12ed7d5b-2895-416f-a681-1f30da85403a" />