### PR TITLE
Darkmode

### DIFF
--- a/taplt/__main__.py
+++ b/taplt/__main__.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from PySide6.QtWidgets import QApplication
 from PySide6.QtGui import QFont, QFontDatabase
 from taplt.src.main_logic import MainLogic
-from taplt.utils.stylesheets import BASE_FONT_SIZE
+from taplt.utils.stylesheets import BASE_FONT_SIZE, sync_theme_with_system
 
 
 def main(_args):
@@ -21,7 +21,15 @@ def main(_args):
     font_family = QFontDatabase.applicationFontFamilies(font_id)[0]
     global_font = QFont(font_family, BASE_FONT_SIZE)
     app.setFont(global_font)
-    _ = MainLogic()  # the labeling window
+
+    sync_theme_with_system()
+    main_logic = MainLogic()  # the labeling window
+
+    def on_scheme_changed(_scheme):
+        sync_theme_with_system()
+        main_logic.main_window.refresh_theme()
+
+    app.styleHints().colorSchemeChanged.connect(on_scheme_changed)
     sys.exit(app.exec())
 
 

--- a/taplt/macros/macros_dialogs.py
+++ b/taplt/macros/macros_dialogs.py
@@ -3,7 +3,7 @@ from PySide6.QtCore import QSize, Qt
 from PySide6.QtGui import QFont
 
 from pathlib import Path
-from taplt.utils.stylesheets import BUTTON_STYLESHEET, BASE_FONT_SIZE
+from taplt.utils.stylesheets import get_button_stylesheet, BASE_FONT_SIZE
 
 
 class ExampleProjectDialog(QDialog):
@@ -23,7 +23,7 @@ class ExampleProjectDialog(QDialog):
         self.info.setFont(font)
 
         self.button = QPushButton("Show me an example project")
-        self.button.setStyleSheet(BUTTON_STYLESHEET.format(button_size=BASE_FONT_SIZE + 1))
+        self.button.setStyleSheet(get_button_stylesheet(BASE_FONT_SIZE))
         self.button.clicked.connect(self.finish)
 
         self.layout().addWidget(self.info)
@@ -76,7 +76,7 @@ class PreviewDatabaseDialog(QDialog):
                 self.table.setItem(i, j, item)
 
         self.button = QPushButton("Close")
-        self.button.setStyleSheet(BUTTON_STYLESHEET.format(button_size=BASE_FONT_SIZE + 1))
+        self.button.setStyleSheet(get_button_stylesheet(BASE_FONT_SIZE))
         self.button.setFixedSize(80, 60)
         self.button.pressed.connect(self.close)
 

--- a/taplt/ui/annotation_tree.py
+++ b/taplt/ui/annotation_tree.py
@@ -217,6 +217,11 @@ class AnnotationTree(QTreeWidget):
                         item.setCheckState(0, Qt.CheckState.Unchecked)
                     child.addChild(item)
 
+    
+    def refresh_theme(self):
+        """re-applies the theme-dependent stylesheet after a dark-mode toggle"""
+        self.setStyleSheet(get_list_widget_stylesheet())
+
 
 def create_square_icon(color: QColor, size: int = 10) -> QIcon:
     pixmap = QPixmap(size, size)
@@ -228,4 +233,6 @@ def create_square_icon(color: QColor, size: int = 10) -> QIcon:
     icon = QIcon(pixmap)
     painter.end()
     return icon
+
+
 

--- a/taplt/ui/annotation_tree.py
+++ b/taplt/ui/annotation_tree.py
@@ -6,6 +6,7 @@ from taplt.ui.dialogs import CommentDialog, DeleteAllMessageBox, DeleteClassMess
 from taplt.ui.shape import Shape
 
 from typing import List
+from taplt.utils.stylesheets import LIST_WIDGET_STYLESHEET
 
 
 class TreeWidgetItem(QTreeWidgetItem):
@@ -31,6 +32,7 @@ class AnnotationTree(QTreeWidget):
 
         self.setColumnCount(2)
         self.setFrameShape(QFrame.Shape.NoFrame)
+        self.setStyleSheet(LIST_WIDGET_STYLESHEET)
         self.setHeaderLabels(["Annotation", "Your notes"])
 
         self.top = TreeWidgetItem(["Annotations", ""])

--- a/taplt/ui/annotation_tree.py
+++ b/taplt/ui/annotation_tree.py
@@ -6,7 +6,7 @@ from taplt.ui.dialogs import CommentDialog, DeleteAllMessageBox, DeleteClassMess
 from taplt.ui.shape import Shape
 
 from typing import List
-from taplt.utils.stylesheets import LIST_WIDGET_STYLESHEET
+from taplt.utils.stylesheets import get_list_widget_stylesheet
 
 
 class TreeWidgetItem(QTreeWidgetItem):
@@ -32,7 +32,7 @@ class AnnotationTree(QTreeWidget):
 
         self.setColumnCount(2)
         self.setFrameShape(QFrame.Shape.NoFrame)
-        self.setStyleSheet(LIST_WIDGET_STYLESHEET)
+        self.setStyleSheet(get_list_widget_stylesheet())
         self.setHeaderLabels(["Annotation", "Your notes"])
 
         self.top = TreeWidgetItem(["Annotations", ""])

--- a/taplt/ui/dialogs.py
+++ b/taplt/ui/dialogs.py
@@ -269,14 +269,14 @@ class ProjectHandlerDialog(QDialog):
         # button to open up a FileDialog
         self.select_path_button = QPushButton()
         self.select_path_button.setFixedSize(QSize(40, 30))
-        self.select_path_button.setStyleSheet(BUTTON_STYLESHEET.format(button_size=BASE_FONT_SIZE + 1))
+        self.select_path_button.setStyleSheet(get_button_stylesheet(BASE_FONT_SIZE))
         self.select_path_button.setText('...')
         self.select_path_button.clicked.connect(self.select_path)
 
         # button to add initial files
         self.add_files_button = QPushButton()
         self.add_files_button.setFixedWidth(180)
-        self.add_files_button.setStyleSheet(BUTTON_STYLESHEET.format(button_size=BASE_FONT_SIZE + 1))
+        self.add_files_button.setStyleSheet(get_button_stylesheet(BASE_FONT_SIZE))
         self.add_files_button.setText("Add files to get started")
         self.add_files_button.clicked.connect(self.add_files)
 

--- a/taplt/ui/dialogs.py
+++ b/taplt/ui/dialogs.py
@@ -9,7 +9,7 @@ import os
 
 from taplt.ui.list_widgets import LabelList, SettingList
 from taplt.utils.qt import get_icon
-from taplt.utils.stylesheets import BUTTON_STYLESHEET, BASE_FONT_SIZE
+from taplt.utils.stylesheets import get_button_stylesheet, BASE_FONT_SIZE
 
 
 class CloseMessageBox(QMessageBox):

--- a/taplt/ui/file_display.py
+++ b/taplt/ui/file_display.py
@@ -10,7 +10,7 @@ from taplt.ui.annotation_group import AnnotationGroup
 from taplt.ui.shape import Shape
 from taplt.utils.qt import get_icon
 from taplt.utils.project_structure import modality, Modality
-from taplt.utils.stylesheets import LABEL_STYLESHEET
+from taplt.utils.stylesheets import get_label_stylesheet
 
 class CenterDisplayWidget(QWidget):
     """ widget to manage the central display in the GUI
@@ -50,7 +50,7 @@ class CenterDisplayWidget(QWidget):
         # QLabel displaying the patient's id/name/alias
         self.patient_label = QLabel()
         self.patient_label.setContentsMargins(10, 0, 10, 0)
-        self.patient_label.setStyleSheet(LABEL_STYLESHEET)
+        self.patient_label.setStyleSheet(get_label_stylesheet())
 
         self.hide_button = QPushButton(get_icon("next"), "", self)
         self.hide_button.setGeometry(0, 0, 40, 40)

--- a/taplt/ui/file_display.py
+++ b/taplt/ui/file_display.py
@@ -10,7 +10,7 @@ from taplt.ui.annotation_group import AnnotationGroup
 from taplt.ui.shape import Shape
 from taplt.utils.qt import get_icon
 from taplt.utils.project_structure import modality, Modality
-
+from taplt.utils.stylesheets import LABEL_STYLESHEET
 
 class CenterDisplayWidget(QWidget):
     """ widget to manage the central display in the GUI
@@ -50,6 +50,7 @@ class CenterDisplayWidget(QWidget):
         # QLabel displaying the patient's id/name/alias
         self.patient_label = QLabel()
         self.patient_label.setContentsMargins(10, 0, 10, 0)
+        self.patient_label.setStyleSheet(LABEL_STYLESHEET)
 
         self.hide_button = QPushButton(get_icon("next"), "", self)
         self.hide_button.setGeometry(0, 0, 40, 40)

--- a/taplt/ui/list_widgets.py
+++ b/taplt/ui/list_widgets.py
@@ -7,8 +7,10 @@ from typing import List
 
 from taplt.ui.shape import Shape
 from taplt.utils.qt import createListWidgetItemWithSquareIcon, get_icon
-from taplt.utils.stylesheets import TAB_STYLESHEET, SETTING_STYLESHEET, BASE_FONT_SIZE
-
+from taplt.utils.stylesheets import (
+    TAB_STYLESHEET, SETTING_STYLESHEET, BASE_FONT_SIZE,
+    HEADER_LABEL_STYLESHEET, LIST_WIDGET_STYLESHEET
+)
 
 class FileList(QListWidget):
     """ a list widget subclass to make use of context menu"""
@@ -22,6 +24,7 @@ class FileList(QListWidget):
         self.setFrameShape(QFrame.Shape.NoFrame)
         self.setItemAlignment(Qt.AlignmentFlag.AlignLeft)
         self.setAcceptDrops(True)
+        self.setStyleSheet(LIST_WIDGET_STYLESHEET)
 
     def contextMenuEvent(self, event: QContextMenuEvent) -> None:
         item = self.itemAt(event.pos())
@@ -72,6 +75,7 @@ class LabelList(QListWidget):
         super().__init__(*args)
         self._icon_size = 10
         self.setFrameShape(QFrame.Shape.NoFrame)
+        self.setStyleSheet(LIST_WIDGET_STYLESHEET)
 
     def contextMenuEvent(self, event) -> None:
         pos = event.pos()
@@ -108,7 +112,7 @@ class LabelsViewingWidget(QWidget):
         self.layout().setContentsMargins(0, 0, 0, 0)
         self.layout().setSpacing(0)
         self.file_label = QLabel()
-        self.file_label.setStyleSheet("background-color: rgb(186, 189, 182);")
+        self.file_label.setStyleSheet(HEADER_LABEL_STYLESHEET)
         self.file_label.setText("Labels")
         self.file_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.layout().addWidget(self.file_label)
@@ -130,7 +134,7 @@ class FileViewingWidget(QWidget):
         self.layout().setContentsMargins(0, 0, 0, 0)
         self.layout().setSpacing(0)
         self.file_label = QLabel()
-        self.file_label.setStyleSheet("background-color: rgb(186, 189, 182);")
+        self.file_label.setStyleSheet(HEADER_LABEL_STYLESHEET)
         self.file_label.setText("File List")
         self.file_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.layout().addWidget(self.file_label)

--- a/taplt/ui/list_widgets.py
+++ b/taplt/ui/list_widgets.py
@@ -8,8 +8,8 @@ from typing import List
 from taplt.ui.shape import Shape
 from taplt.utils.qt import createListWidgetItemWithSquareIcon, get_icon
 from taplt.utils.stylesheets import (
-    TAB_STYLESHEET, SETTING_STYLESHEET, BASE_FONT_SIZE,
-    HEADER_LABEL_STYLESHEET, LIST_WIDGET_STYLESHEET
+    get_tab_stylesheet, SETTING_STYLESHEET, BASE_FONT_SIZE,
+    get_header_label_stylesheet, get_list_widget_stylesheet
 )
 
 class FileList(QListWidget):
@@ -24,7 +24,7 @@ class FileList(QListWidget):
         self.setFrameShape(QFrame.Shape.NoFrame)
         self.setItemAlignment(Qt.AlignmentFlag.AlignLeft)
         self.setAcceptDrops(True)
-        self.setStyleSheet(LIST_WIDGET_STYLESHEET)
+        self.setStyleSheet(get_list_widget_stylesheet())
 
     def contextMenuEvent(self, event: QContextMenuEvent) -> None:
         item = self.itemAt(event.pos())
@@ -68,6 +68,9 @@ class FileList(QListWidget):
 
         event.acceptProposedAction()
 
+    def refresh_theme(self):
+        self.setStyleSheet(get_list_widget_stylesheet())
+
 
 class LabelList(QListWidget):
     """ a list widget to store annotation labels"""
@@ -75,7 +78,7 @@ class LabelList(QListWidget):
         super().__init__(*args)
         self._icon_size = 10
         self.setFrameShape(QFrame.Shape.NoFrame)
-        self.setStyleSheet(LIST_WIDGET_STYLESHEET)
+        self.setStyleSheet(get_list_widget_stylesheet())
 
     def contextMenuEvent(self, event) -> None:
         pos = event.pos()
@@ -103,6 +106,9 @@ class LabelList(QListWidget):
             item = createListWidgetItemWithSquareIcon(txt, col, self._icon_size)
             self.addItem(item)
 
+    def refresh_theme(self):
+        self.setStyleSheet(get_list_widget_stylesheet())
+
 
 class LabelsViewingWidget(QWidget):
     """ a widget to hold a LabelList displaying the (unique) label class names"""
@@ -112,13 +118,17 @@ class LabelsViewingWidget(QWidget):
         self.layout().setContentsMargins(0, 0, 0, 0)
         self.layout().setSpacing(0)
         self.file_label = QLabel()
-        self.file_label.setStyleSheet(HEADER_LABEL_STYLESHEET)
+        self.file_label.setStyleSheet(get_header_label_stylesheet())
         self.file_label.setText("Labels")
         self.file_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.layout().addWidget(self.file_label)
         self.label_list = LabelList()
         self.label_list.setSelectionMode(QAbstractItemView.SelectionMode.NoSelection)
         self.layout().addWidget(self.label_list)
+
+    def refresh_theme(self):
+        self.file_label.setStyleSheet(get_header_label_stylesheet())
+        self.label_list.refresh_theme()
 
 
 class FileViewingWidget(QWidget):
@@ -134,14 +144,14 @@ class FileViewingWidget(QWidget):
         self.layout().setContentsMargins(0, 0, 0, 0)
         self.layout().setSpacing(0)
         self.file_label = QLabel()
-        self.file_label.setStyleSheet(HEADER_LABEL_STYLESHEET)
+        self.file_label.setStyleSheet(get_header_label_stylesheet())
         self.file_label.setText("File List")
         self.file_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.layout().addWidget(self.file_label)
 
         self.tab = QTabWidget()
         self.tab.setContentsMargins(0, 0, 0, 0)
-        self.tab.setStyleSheet(TAB_STYLESHEET.format(tab_size=BASE_FONT_SIZE))
+        self.tab.setStyleSheet(get_tab_stylesheet(BASE_FONT_SIZE))
         self.search_field = QTextEdit()
 
         # Size Policy
@@ -180,6 +190,13 @@ class FileViewingWidget(QWidget):
         self.image_list.sDeleteFile.connect(self.sDeleteFile.emit)
         self.wsi_list.sDeleteFile.connect(self.sDeleteFile.emit)
         self.search_field.textChanged.connect(self.search_text_changed)
+
+
+    def refresh_theme(self):
+        self.file_label.setStyleSheet(get_header_label_stylesheet())
+        self.tab.setStyleSheet(get_tab_stylesheet(BASE_FONT_SIZE))
+        self.image_list.refresh_theme()
+        self.wsi_list.refresh_theme()
 
     def file_selected(self):
         """gets the index of the selected file and emits a signal"""

--- a/taplt/ui/main_window.py
+++ b/taplt/ui/main_window.py
@@ -272,6 +272,7 @@ class LabelingMainWindow(QMainWindow):
         self.labels_list.refresh_theme()
         self.file_list.refresh_theme()
         self.toolBar.refresh_theme()
+        self.polygons.refresh_theme()
 
     def change_detected(self, change: int):
         """appends the detected change to the changes list"""

--- a/taplt/ui/main_window.py
+++ b/taplt/ui/main_window.py
@@ -16,7 +16,9 @@ from taplt.ui.annotation_tree import AnnotationTree
 from taplt.ui.welcome_screen import WelcomeScreen
 from taplt.utils.qt import colormap_rgb, get_icon
 from taplt.utils.project_structure import check_environment, Structure
-from taplt.utils.stylesheets import TAB_STYLESHEET, FONT_SMALL, FONT_MEDIUM, FONT_LARGE
+from taplt.utils.stylesheets import (get_tab_stylesheet, get_header_label_stylesheet,
+                                     OVERLAY_LABEL_STYLESHEET, set_theme,
+                                     FONT_SMALL, FONT_MEDIUM, FONT_LARGE, BASE_FONT_SIZE)
 from taplt.macros.macros import Macros
 from taplt.macros.macros_dialogs import PreviewDatabaseDialog
 from taplt import source_directory
@@ -76,12 +78,7 @@ class LabelingMainWindow(QMainWindow):
 
         # zoom label on top right side
         self.zoom_label = QLabel("100%", self.file_display)
-        self.zoom_label.setStyleSheet("""
-            background-color: rgba(0,0,0,150);
-            color: white;
-            padding: 2px 6px;
-            border-radius: 3px;
-            """)
+        self.zoom_label.setStyleSheet(OVERLAY_LABEL_STYLESHEET)
         self.zoom_label.adjustSize()
         self.zoom_label.raise_()
         self.file_display.hide_button.setVisible(False)
@@ -114,7 +111,7 @@ class LabelingMainWindow(QMainWindow):
         self.poly_widget.layout().setContentsMargins(0, 0, 0, 0)
         self.poly_widget.layout().setSpacing(0)
         self.poly_label = QLabel(self)
-        self.poly_label.setStyleSheet("background-color: rgb(186, 189, 182);")
+        self.poly_label.setStyleSheet(get_header_label_stylesheet())
         self.poly_label.setText("Polygons")
         self.poly_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.poly_widget.layout().addWidget(self.poly_label)
@@ -231,6 +228,7 @@ class LabelingMainWindow(QMainWindow):
     def apply_settings(self, settings: list):
         """applies the settings"""
         font_size = None
+        theme_changed = False
         for setting in settings:
             if setting[0] == "Autosave on file change":
                 self.autoSave = normalize_setting_value(setting[1])
@@ -252,7 +250,7 @@ class LabelingMainWindow(QMainWindow):
             font = QFont(QApplication.instance().font())
             font.setPointSize(font_size)
             QApplication.instance().setFont(font)
-            self.file_list.tab.setStyleSheet(TAB_STYLESHEET.format(tab_size=font_size))
+            self.file_list.tab.setStyleSheet(get_tab_stylesheet(font_size))
             self.file_list.search_field.setFont(font)
             self.file_list.image_list.setFont(font)
             self.file_list.wsi_list.setFont(font)
@@ -263,7 +261,17 @@ class LabelingMainWindow(QMainWindow):
                 button.setFont(font)
                 self.toolBar.update_button_sizes()
 
+        if theme_changed:
+            self.refresh_theme()
+
         self.sUpdateSettings.emit(settings)
+
+    def refresh_theme(self):
+        """re-applies all theme-dependent stylesheets after a dark-mode toggle"""
+        self.poly_label.setStyleSheet(get_header_label_stylesheet())
+        self.labels_list.refresh_theme()
+        self.file_list.refresh_theme()
+        self.toolBar.refresh_theme()
 
     def change_detected(self, change: int):
         """appends the detected change to the changes list"""

--- a/taplt/ui/toolbar.py
+++ b/taplt/ui/toolbar.py
@@ -4,6 +4,7 @@ from PySide6.QtCore import *
 from typing import *
 
 from taplt.src.actions import Action
+from taplt.utils.stylesheets import TOOLBAR_BUTTON_STYLESHEET
 
 
 class Toolbar(QWidget):
@@ -87,11 +88,7 @@ class Toolbar(QWidget):
         btn.setDefaultAction(action)
         btn.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextUnderIcon)
         btn.setIconSize(QSize(24, 24))
-        btn.setStyleSheet("""
-            QToolButton {
-                qproperty-iconSize: 24px 24px;
-            }      
-        """)
+        btn.setStyleSheet(TOOLBAR_BUTTON_STYLESHEET)
 
         self.layout().addWidget(btn)
         self.update_button_sizes()

--- a/taplt/ui/toolbar.py
+++ b/taplt/ui/toolbar.py
@@ -4,7 +4,7 @@ from PySide6.QtCore import *
 from typing import *
 
 from taplt.src.actions import Action
-from taplt.utils.stylesheets import TOOLBAR_BUTTON_STYLESHEET
+from taplt.utils.stylesheets import get_toolbar_button_stylesheet, get_toolbar_background_stylesheet
 
 
 class Toolbar(QWidget):
@@ -26,7 +26,7 @@ class Toolbar(QWidget):
         self.actionsDict = {}  # This is a lookup table to match the buttons to the numbers they got added
 
         self.setAutoFillBackground(False)
-        self.setStyleSheet("background-color: rgb(186, 189, 182);")
+        self.setStyleSheet(get_toolbar_background_stylesheet())
         self.setObjectName("toolBar")
         self.button_group = QButtonGroup()
         self.button_group.setExclusive(True)
@@ -88,7 +88,7 @@ class Toolbar(QWidget):
         btn.setDefaultAction(action)
         btn.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextUnderIcon)
         btn.setIconSize(QSize(24, 24))
-        btn.setStyleSheet(TOOLBAR_BUTTON_STYLESHEET)
+        btn.setStyleSheet(get_toolbar_button_stylesheet())
 
         self.layout().addWidget(btn)
         self.update_button_sizes()
@@ -302,3 +302,11 @@ class Toolbar(QWidget):
                 return True
 
         return super().eventFilter(obj, event)
+
+    def refresh_theme(self):
+        """
+        re-applies theme-dependent styling to the toolbar and all its buttons
+        """
+        self.setStyleSheet(get_toolbar_background_stylesheet())
+        for btn in self.findChildren(QToolButton):
+            btn.setStyleSheet(get_toolbar_button_stylesheet())

--- a/taplt/utils/stylesheets.py
+++ b/taplt/utils/stylesheets.py
@@ -1,31 +1,56 @@
+from PySide6.QtGui import QGuiApplication
+from PySide6.QtCore import Qt
+
 FONT_SMALL = 9
 FONT_MEDIUM = 11
 FONT_LARGE = 13
 
 # color palette
-COLOR_BG = "rgb(240, 240, 240)"
-COLOR_BG_HEADER = "rgb(186, 189, 182)"  
-COLOR_BG_HOVER = "rgb(220, 220, 220)"
-COLOR_BG_SELECTED = "rgb(180, 200, 230)"
-COLOR_TEXT = "black"
-COLOR_BORDER = "lightgray"
+THEMES = {
+    "light": dict(bg="rgb(240,240,240)", bg_header="rgb(186,189,182)",
+                  bg_hover="rgb(220,220,220)", bg_selected="rgb(180,200,230)",
+                  text="black", text_selected="black", border="lightgray"),
+    "dark": dict(bg="rgb(45,45,45)", bg_header="rgb(60,60,60)",
+                 bg_hover="rgb(70,70,70)", bg_selected="rgb(70,100,140)",
+                 text="white", text_selected="black", border="rgb(80,80,80)"),
+}
+
+ACTIVE_THEME = "light"  
 
 
 BASE_FONT_SIZE = FONT_MEDIUM
 
-BUTTON_STYLESHEET = """QPushButton {{
-                       background-color: {bg};
-                       color: {text};
+
+def set_theme(dark: bool):
+    """switches the globally active theme; existing widgets must re-apply their stylesheet afterwards"""
+    global ACTIVE_THEME
+    ACTIVE_THEME = "dark" if dark else "light"
+
+
+def current_theme() -> dict:
+    return THEMES[ACTIVE_THEME]
+
+
+def sync_theme_with_system():
+    """reads the current OS color scheme and applies it"""
+    scheme = QGuiApplication.styleHints().colorScheme()
+    set_theme(scheme == Qt.ColorScheme.Dark)
+
+def get_button_stylesheet(button_size: int = BASE_FONT_SIZE) -> str:
+    c = current_theme()
+    return f"""QPushButton {{
+                       background-color: {c['bg']};
+                       color: {c['text']};
                        min-height: 2em;
                        border-width: 2px;
                        border-radius: 8px;
                        border-color: black;
-                       font: bold {{button_size}}px;
+                       font: bold {button_size}px;
                        padding: 2px;
                        }}
                        
                        QPushButton::hover {{
-                       background-color: {hover};
+                       background-color: {c['bg_hover']};
                        }}
                        
                        QPushButton::pressed {{
@@ -33,8 +58,10 @@ BUTTON_STYLESHEET = """QPushButton {{
                        }}
                        """
 
-TAB_STYLESHEET = """ QTabWidget::pane {{{{
-                     border: 1px solid {border};
+def get_tab_stylesheet(tab_size: int = BASE_FONT_SIZE) -> str:
+    c = current_theme()
+    return f""" QTabWidget::pane {{{{
+                     border: 1px solid {c['border']};
                      top:-1px;
                      }}}}
                      
@@ -43,62 +70,84 @@ TAB_STYLESHEET = """ QTabWidget::pane {{{{
                      }}}}
                      
                      QTabBar::tab {{{{
-                     background: {bg_header};
-                     color: {text};
+                     background: {c['bg_header']};
+                     color: {c['text']};
                      min-width: 8ex; 
                      padding: 7px;
                      font-size: {{tab_size}}px;
                      }}}}
                      
                      QTabBar::tab:hover {{{{ 
-                     background: {hover};
+                     background: {c['bg_hover']};
                      }}}}
                      
                      QTabBar::tab:selected {{{{
-                     background: {bg}; 
-                     border-left: 1px solid {border};
-                     border-right: 1px solid {border}; 
+                     background: {c['bg']}; 
+                     border-left: 1px solid {c['border']};
+                     border-right: 1px solid {c['border']}; 
                      border-top: none;
                      border-bottom: none;
                      font: bold;
                      }}}}
-                     """.format(border=COLOR_BORDER, bg_header=COLOR_BG_HEADER,
-                                text=COLOR_TEXT, hover=COLOR_BG_HOVER, bg=COLOR_BG)
+                     """
 
 SETTING_STYLESHEET = """ QListWidget::item:hover:!active
                          """
 
-HEADER_LABEL_STYLESHEET = f"background-color: {COLOR_BG_HEADER}; color: {COLOR_TEXT};"
+def get_header_label_stylesheet() -> str:
+    c = current_theme()
+    return f"background-color: {c['bg_header']}; color: {c['text']};"
 
-LIST_WIDGET_STYLESHEET = f"""
-    QListWidget, QTreeWidget {{
-        background-color: {COLOR_BG};
-        color: {COLOR_TEXT};
-    }}
-    QListWidget::item:hover, QTreeWidget::item:hover {{
-        background-color: {COLOR_BG_HOVER};
-    }}
-    QListWidget::item:selected, QTreeWidget::item:selected {{
-        background-color: {COLOR_BG_SELECTED};
-    }}
-    QHeaderView::section {{
-        background-color: {COLOR_BG_HEADER};
-        color: {COLOR_TEXT};
-    }}
+def get_list_widget_stylesheet() -> str:
+    c = current_theme()
+    return f"""
+        QListWidget, QTreeWidget {{
+            background-color: {c['bg']};
+            color: {c['text']};
+        }}
+        QListWidget::item:hover, QTreeWidget::item:hover {{
+            background-color: {c['bg_hover']};
+        }}
+        QListWidget::item:selected, QTreeWidget::item:selected {{
+            background-color: {c['bg_selected']};
+            color: {c['text_selected']}
+        }}
+        QHeaderView::section {{
+            background-color: {c['bg_header']};
+            color: {c['text']};
+        }}
+    """
+
+
+def get_toolbar_button_stylesheet() -> str:
+    c = current_theme()
+    return f"""
+        QToolButton {{
+            qproperty-iconSize: 24px 24px;
+            color: {c['text']};
+            background-color: {c['bg_header']};
+        }}
+        QToolButton::icon {{
+            margin-top: 16px;
+        }}
+        QToolButton:checked {{
+            background-color: {c['bg_hover']};
+        }}
+    """
+
+
+def get_label_stylesheet() -> str:
+    c = current_theme()
+    return f"color: {c['text']}; background-color: {c['bg']};"
+
+
+def get_toolbar_background_stylesheet() -> str:
+    c = current_theme()
+    return f"background-color: {c['bg_header']};"
+
+OVERLAY_LABEL_STYLESHEET = """
+    background-color: rgba(0, 0, 0, 150);
+    color: white;
+    padding: 2px 6px;
+    border-radius: 3px;
 """
-
-TOOLBAR_BUTTON_STYLESHEET = f"""
-    QToolButton {{
-        qproperty-iconSize: 24px 24px;
-        color: {COLOR_TEXT};
-        background-color: {COLOR_BG_HEADER};
-    }}
-    QToolButton::icon {{
-        margin-top: 16px;
-    }}
-    QToolButton:checked {{
-        background-color: {COLOR_BG_HOVER};
-    }}
-"""
-
-LABEL_STYLESHEET = f"color: {COLOR_TEXT}; background-color: {COLOR_BG};"

--- a/taplt/utils/stylesheets.py
+++ b/taplt/utils/stylesheets.py
@@ -33,35 +33,35 @@ BUTTON_STYLESHEET = """QPushButton {{
                        }}
                        """
 
-TAB_STYLESHEET = """ QTabWidget::pane {{
+TAB_STYLESHEET = """ QTabWidget::pane {{{{
                      border: 1px solid {border};
                      top:-1px;
-                     }} 
+                     }}}}
                      
-                     QTabWidget::tab-bar {{
+                     QTabWidget::tab-bar {{{{
                      left: 0px;
-                     }}
+                     }}}}
                      
-                     QTabBar::tab {{
+                     QTabBar::tab {{{{
                      background: {bg_header};
                      color: {text};
                      min-width: 8ex; 
                      padding: 7px;
                      font-size: {{tab_size}}px;
-                     }}
+                     }}}}
                      
-                     QTabBar::tab:hover {{ 
+                     QTabBar::tab:hover {{{{ 
                      background: {hover};
-                     }}
+                     }}}}
                      
-                     QTabBar::tab:selected {{
+                     QTabBar::tab:selected {{{{
                      background: {bg}; 
                      border-left: 1px solid {border};
                      border-right: 1px solid {border}; 
                      border-top: none;
                      border-bottom: none;
                      font: bold;
-                     }}
+                     }}}}
                      """.format(border=COLOR_BORDER, bg_header=COLOR_BG_HEADER,
                                 text=COLOR_TEXT, hover=COLOR_BG_HOVER, bg=COLOR_BG)
 

--- a/taplt/utils/stylesheets.py
+++ b/taplt/utils/stylesheets.py
@@ -2,11 +2,20 @@ FONT_SMALL = 9
 FONT_MEDIUM = 11
 FONT_LARGE = 13
 
+# color palette
+COLOR_BG = "rgb(240, 240, 240)"
+COLOR_BG_HEADER = "rgb(186, 189, 182)"  
+COLOR_BG_HOVER = "rgb(220, 220, 220)"
+COLOR_BG_SELECTED = "rgb(180, 200, 230)"
+COLOR_TEXT = "black"
+COLOR_BORDER = "lightgray"
+
+
 BASE_FONT_SIZE = FONT_MEDIUM
 
 BUTTON_STYLESHEET = """QPushButton {{
-                       background-color: lightgray;
-                       color: black;
+                       background-color: {bg};
+                       color: {text};
                        min-height: 2em;
                        border-width: 2px;
                        border-radius: 8px;
@@ -16,7 +25,7 @@ BUTTON_STYLESHEET = """QPushButton {{
                        }}
                        
                        QPushButton::hover {{
-                       background-color: gray;
+                       background-color: {hover};
                        }}
                        
                        QPushButton::pressed {{
@@ -25,7 +34,7 @@ BUTTON_STYLESHEET = """QPushButton {{
                        """
 
 TAB_STYLESHEET = """ QTabWidget::pane {{
-                     border: 1px solid lightgray;
+                     border: 1px solid {border};
                      top:-1px;
                      }} 
                      
@@ -34,25 +43,62 @@ TAB_STYLESHEET = """ QTabWidget::pane {{
                      }}
                      
                      QTabBar::tab {{
-                     background: rgb(205, 205, 212);
+                     background: {bg_header};
+                     color: {text};
                      min-width: 8ex; 
                      padding: 7px;
                      font-size: {{tab_size}}px;
                      }}
                      
                      QTabBar::tab:hover {{ 
-                     background: rgb(220, 220, 220);
+                     background: {hover};
                      }}
                      
                      QTabBar::tab:selected {{
-                     background: rgb(240, 240, 240); 
-                     border-left: 1px solid lightgray;
-                     border-right: 1px solid lightgray; 
+                     background: {bg}; 
+                     border-left: 1px solid {border};
+                     border-right: 1px solid {border}; 
                      border-top: none;
                      border-bottom: none;
                      font: bold;
                      }}
-                     """
+                     """.format(border=COLOR_BORDER, bg_header=COLOR_BG_HEADER,
+                                text=COLOR_TEXT, hover=COLOR_BG_HOVER, bg=COLOR_BG)
 
 SETTING_STYLESHEET = """ QListWidget::item:hover:!active
                          """
+
+HEADER_LABEL_STYLESHEET = f"background-color: {COLOR_BG_HEADER}; color: {COLOR_TEXT};"
+
+LIST_WIDGET_STYLESHEET = f"""
+    QListWidget, QTreeWidget {{
+        background-color: {COLOR_BG};
+        color: {COLOR_TEXT};
+    }}
+    QListWidget::item:hover, QTreeWidget::item:hover {{
+        background-color: {COLOR_BG_HOVER};
+    }}
+    QListWidget::item:selected, QTreeWidget::item:selected {{
+        background-color: {COLOR_BG_SELECTED};
+    }}
+    QHeaderView::section {{
+        background-color: {COLOR_BG_HEADER};
+        color: {COLOR_TEXT};
+    }}
+"""
+
+TOOLBAR_BUTTON_STYLESHEET = f"""
+    QToolButton {{
+        qproperty-iconSize: 24px 24px;
+        color: {COLOR_TEXT};
+        background-color: {COLOR_BG_HEADER};
+    }}
+    QToolButton::icon {{
+        margin-top: 16px;
+    }}
+    QToolButton:checked {{
+        background-color: {COLOR_BG_HOVER};
+    }}
+"""
+
+LABEL_STYLESHEET = f"color: {COLOR_TEXT}; background-color: {COLOR_BG};"


### PR DESCRIPTION
resolves #69 
in `stylesheets.py`: 
- System umgestellt auf Funktionen, die jeweils auf das aktuell aktive Theme zugreifen (light/ dark)
- zentrale Verwaltung des Themes
in `main_window`:
- hard codierte Stylesheets ersetzt
- Methode `refresh_theme()`, um alle relevanten Stylesheets zu ändern
in `__main__.py`:
- sync_theme_with_system() wird beim App-Start vor dem Aufbau der Fenster aufgerufen, damit die UI direkt im korrekten Theme gerendert wird
- Live-Reaktion auf Windows-Theme-Wechsel während der Laufzeit über app.styleHints().colorSchemeChanged, das sync_theme_with_system() + main_window.refresh_theme() erneut auslöst
- MainLogic()-Instanz wird jetzt einer Variable zugewiesen (statt _), um im Callback darauf zugreifen zu können

alle anderen Dateien: hard codierte Stylesheets ersetzt
=> jetzt ändert sich das Stylesheet live passend zu den jeweiligen Systemeinstellungen
<img width="1906" height="1116" alt="grafik" src="https://github.com/user-attachments/assets/8842f44d-32fd-4b4e-931d-90c190c91478" />
