### PR TITLE
set correct index for mouse tip

### DIFF
--- a/taplt/ui/annotation_group.py
+++ b/taplt/ui/annotation_group.py
@@ -65,13 +65,17 @@ class AnnotationGroup(QGraphicsObject):
             scene_event = event
         else:
             scene = self.scene()
-            view = scene.views()[0] if scene and scene.views() else None
-            if view is None:
+            if scene is None:
                 return
 
             # map the event's global position into the view's viewport so the
             # resulting scene coordinate corresponds to the actual mouse tip
             # (not the widget-local center)
+            view = next((v for v in scene.views() if v.isVisible()), None)
+            if view is None:
+                view = scene.views()[0] if scene.views() else None
+            if view is None:
+                return
             scene_pos = view.mapToScene(view.viewport().mapFromGlobal(event.globalPosition().toPoint()))
             scene_event = QGraphicsSceneMouseEvent(QEvent.GraphicsSceneMousePress)
             scene_event.setPos(scene_pos)


### PR DESCRIPTION
### Description
`CenterDisplayWidget` attaches three `QGraphicsViews` (`image_viewer`, `video_player`, `slide_viewer`) to a single shared `QGraphicsScene`. 
`AnnotationGroup.forward_click()`, which synthesizes the scene-space mouse event for the first click of a new shape, picks the view to map coordinates through:
```python 
view = scene.views()[0] if scene and scene.views() else None
```
`scene.views()` returns all attached views in attachment order, not the currently visible/active one. Since `image_viewer` is always attached first, it's always used for the coordinate mapping, even when `slide_viewer` is the visible view (i.e. whenever a WSI is open). This mismatched transform is why only the first point (the one routed through forward_click) is off; later points are handled by the shape's normal event dispatch through the actual active view and are correct.

### Fix
In `forward_click`, select the currently visible view instead of blindly indexing `views()[0]`, falling back to `[0]` only if none is visible:
```python 
view = next((v for v in scene.views() if v.isVisible()), None)
if view is None:
    view = scene.views()[0] if scene.views() else None
```