### PR TITLE
consistent zoom behavior

### DIFF
--- a/taplt/media_viewing_widgets/widgets/image_viewer.py
+++ b/taplt/media_viewing_widgets/widgets/image_viewer.py
@@ -20,7 +20,7 @@ class ImageViewer(QGraphicsView):
 
         # Protected Item
         self._scaling_factor = 5 / 4
-        self._enableZoomPan = False
+        self._enablePan = False
 
     def fitInView(self, rect: QRectF, mode: Qt.AspectRatioMode = Qt.AspectRatioMode.IgnoreAspectRatio) -> None:
         if not rect.isNull():
@@ -42,15 +42,15 @@ class ImageViewer(QGraphicsView):
     def wheelEvent(self, event):
         """Responsible for Zoom.Redefines base function"""
         if not self.b_isEmpty:
-            if self._enableZoomPan:
-                factor = self._scaling_factor if event.angleDelta().y() > 0 else 1/self._scaling_factor
-                self.scale(factor, factor)
+            
+            factor = self._scaling_factor if event.angleDelta().y() > 0 else 1/self._scaling_factor
+            self.scale(factor, factor)
             self._emit_zoom()
 
     def keyPressEvent(self, event) -> None:
         if not self.b_isEmpty:
             if event.key() == Qt.Key.Key_Control:
-                self._enableZoomPan = True
+                self._enablePan = True
                 self.setDragMode(QGraphicsView.DragMode.ScrollHandDrag)
             elif event.key() == Qt.Key.Key_Left:
                 self.sNextFile.emit(-1)
@@ -62,7 +62,7 @@ class ImageViewer(QGraphicsView):
     def keyReleaseEvent(self, event) -> None:
         if not self.b_isEmpty:
             if event.key() == Qt.Key.Key_Control:
-                self._enableZoomPan = False
+                self._enablePan = False
                 self.setDragMode(QGraphicsView.DragMode.NoDrag)
 
     def _emit_zoom(self):

--- a/taplt/ui/image_viewer.py
+++ b/taplt/ui/image_viewer.py
@@ -19,7 +19,7 @@ class ImageViewer(QGraphicsView):
 
         # Protected Item
         self._scaling_factor = 5 / 4
-        self._enableZoomPan = False
+        self._enablePan = False
 
     def fitInView(self, rect: QRectF, mode: Qt.AspectRatioMode = Qt.AspectRatioMode.IgnoreAspectRatio) -> None:
         if not rect.isNull():
@@ -41,15 +41,15 @@ class ImageViewer(QGraphicsView):
     def wheelEvent(self, event):
         """Responsible for Zoom.Redefines base function"""
         if not self.b_isEmpty:
-            if self._enableZoomPan:
-                factor = self._scaling_factor if event.angleDelta().y() > 0 else 1/self._scaling_factor
-                self.scale(factor, factor)
+            
+            factor = self._scaling_factor if event.angleDelta().y() > 0 else 1/self._scaling_factor
+            self.scale(factor, factor)
             self._emit_zoom()
 
     def keyPressEvent(self, event) -> None:
         if not self.b_isEmpty:
             if event.key() == Qt.Key.Key_Control:
-                self._enableZoomPan = True
+                self._enablePan = True
                 self.setDragMode(QGraphicsView.DragMode.ScrollHandDrag)
             elif event.key() == Qt.Key.Key_Left:
                 self.sNextFile.emit(-1)
@@ -59,7 +59,7 @@ class ImageViewer(QGraphicsView):
     def keyReleaseEvent(self, event) -> None:
         if not self.b_isEmpty:
             if event.key() == Qt.Key.Key_Control:
-                self._enableZoomPan = False
+                self._enablePan = False
                 self.setDragMode(QGraphicsView.DragMode.NoDrag)
 
 


### PR DESCRIPTION
resolves #92 
Änderungen: `_enableZoomPan` wurde zu `_enablePan` geändert und behandelt jetzt nur noch panning. `wheelEvent` hat damit jetzt nichts mehr zu tun -> Zoomen ist bei images jetzt auch ohne gedrückte strg taste möglich.