### PR TITLE
zoom label 100% beim Öffnen

### DIFF
--- a/taplt/media_viewing_widgets/widgets/image_viewer.py
+++ b/taplt/media_viewing_widgets/widgets/image_viewer.py
@@ -21,6 +21,7 @@ class ImageViewer(QGraphicsView):
         # Protected Item
         self._scaling_factor = 5 / 4
         self._enableZoomPan = False
+        self._base_scale = 1.0
 
     def fitInView(self, rect: QRectF, mode: Qt.AspectRatioMode = Qt.AspectRatioMode.IgnoreAspectRatio) -> None:
         if not rect.isNull():
@@ -33,6 +34,7 @@ class ImageViewer(QGraphicsView):
                 factor = min(view_rect.width() / scene_rect.width(),
                              view_rect.height() / scene_rect.height())
                 self.scale(factor, factor)
+                self._base_scale = float(self.transform().m11())
                 self._emit_zoom()
 
     def resizeEvent(self, event: QResizeEvent) -> None:
@@ -66,7 +68,8 @@ class ImageViewer(QGraphicsView):
                 self.setDragMode(QGraphicsView.DragMode.NoDrag)
 
     def _emit_zoom(self):
-        current_zoom = float(self.transform().m11())
+        """emits the zoom level relative to the 'fit to view' scale"""
+        current_zoom = float(self.transform().m11()) / self._base_scale
         parent = self.parentWidget()
         if hasattr(parent, "sZoomChanged"):
             parent.sZoomChanged.emit(current_zoom)

--- a/taplt/ui/main_window.py
+++ b/taplt/ui/main_window.py
@@ -536,7 +536,7 @@ class LabelingMainWindow(QMainWindow):
 
         self.update_toolbar()
         QTimer.singleShot(50, self._reposition_zoom_label)
-        QTimer.singleShot(50, lambda: (self.zoom_label.setText("100%"), self.zoom_label.adjustSize()))
+        
         
     def update_toolbar(self):
         self.toolBar.adjustSize()


### PR DESCRIPTION
resolves #94 
`_emit_zoom()` berechnet den Wert jetzt relativ zur FIt-Skalierung -> gibt 100% bei voll geöffnetem Bild.
der hardgecodete Wert in `update_window()` in `main_window.py` wurde gelöscht