### PR TITLE
Annotation Cancellation 

### DIFF
--- a/taplt/media_viewing_widgets/widgets/image_viewer.py
+++ b/taplt/media_viewing_widgets/widgets/image_viewer.py
@@ -6,6 +6,7 @@ from PySide6.QtWidgets import *
 class ImageViewer(QGraphicsView):
     sNextFile = Signal(int)
     sEnterPressed = Signal()
+    sEscapePressed = Signal()
 
     def __init__(self, *args):
         super(ImageViewer, self).__init__(*args)
@@ -58,6 +59,8 @@ class ImageViewer(QGraphicsView):
                 self.sNextFile.emit(1)
             elif event.key() == Qt.Key.Key_Return or event.key() == Qt.Key.Key_Enter:
                 self.sEnterPressed.emit()
+            elif event.key() == Qt.Key.Key_Escape:
+                self.sEscapePressed.emit()
 
     def keyReleaseEvent(self, event) -> None:
         if not self.b_isEmpty:

--- a/taplt/media_viewing_widgets/widgets/slide_viewer.py
+++ b/taplt/media_viewing_widgets/widgets/slide_viewer.py
@@ -18,6 +18,7 @@ class SlideView(QGraphicsView):
     pixmapFinished = Signal()
     sZoomChanged = Signal(float)
     sEnterPressed = Signal()
+    sEscapePressed = Signal()
 
     sViewChanged = Signal(float, float, float, float, float)
 
@@ -391,6 +392,8 @@ class SlideView(QGraphicsView):
     def keyPressEvent(self, event) -> None:
         if event.key() == Qt.Key.Key_Return or event.key() == Qt.Key.Key_Enter:
             self.sEnterPressed.emit()
+        elif event.key() == Qt.Key.Key_Escape:
+            self.sEscapePressed.emit()
     def emit_view_params(self):
         if self.slide is None:
             return

--- a/taplt/ui/annotation_group.py
+++ b/taplt/ui/annotation_group.py
@@ -229,6 +229,12 @@ class AnnotationGroup(QGraphicsObject):
         shape.deleteLater()
         self.temp_shape = None
         self.updateShapes.emit(list(self.annotations.values()))
+
+        if self.pending_shapes:
+            self.sToolTip.emit("Press Enter to label all annotations.")
+        else:
+            self.sToolTip.emit("")
+        self.updateShapes.emit(list(self.annotations.values()))
         
     def clear(self):
         """

--- a/taplt/ui/annotation_group.py
+++ b/taplt/ui/annotation_group.py
@@ -124,9 +124,9 @@ class AnnotationGroup(QGraphicsObject):
                     self.remove_shapes([self.temp_shape])
                 self.temp_shape.sIllegalCircleOnBorder.connect(delete)
             if self.shapeType == Shape.ShapeType.POLYGON:
-                self.sToolTip.emit("Press right click to end the annotation.")
+                self.sToolTip.emit("Right click to end the annotation.")
             else:
-                self.sToolTip.emit("Press left click a 2nd time to end the annotation.")       
+                self.sToolTip.emit("Click to end the annotation.")       
             self.temp_shape.grabMouse()
             if event is not None:
                 self.forward_click(event)

--- a/taplt/ui/annotation_group.py
+++ b/taplt/ui/annotation_group.py
@@ -183,6 +183,14 @@ class AnnotationGroup(QGraphicsObject):
         """
         if shapes is None:
             return
+        if isinstance(shapes, Shape) and shapes is self.temp_shape:
+            self.cancel_drawing()
+            return
+        if isinstance(shapes, list) and self.temp_shape in shapes:
+            self.cancel_drawing()
+            shapes = [s for s in shapes if s is not self.temp_shape]
+            if not shapes:
+                return
         if isinstance(shapes, Shape):
             dlg = DeleteShapeMessageBox(shapes.label)
             dlg.exec()
@@ -202,7 +210,25 @@ class AnnotationGroup(QGraphicsObject):
                 updated_pending_shapes.append(shape)
         self.pending_shapes = updated_pending_shapes
         self.updateShapes.emit(list(self.annotations.values()))
-
+    
+    def cancel_drawing(self):
+        "cancels current drawing and removes the temp shape from the scene and group"
+        if not self.drawing or self.temp_shape is None:
+            return
+        shape = self.temp_shape
+        self.drawing = False
+        if shape.scene() is not None:
+            shape.scene().removeItem(shape)
+        ids_to_remove = [s_id for s_id, s in self.annotations.items() if s is shape]
+        for s_id in ids_to_remove:
+            self.annotations.pop(s_id)
+        if shape in self.pending_shapes:
+            self.pending_shapes.remove(shape)
+        
+        shape.deleteLater()
+        self.temp_shape = None
+        self.updateShapes.emit(list(self.annotations.values()))
+        
     def clear(self):
         """
         Clears the group and scene of shapes

--- a/taplt/ui/annotation_group.py
+++ b/taplt/ui/annotation_group.py
@@ -55,6 +55,7 @@ class AnnotationGroup(QGraphicsObject):
     @Slot()
     def set_drawing_to_false(self):
         self.drawing = False
+        self.temp_shape = None
         if self.pending_shapes:
             self.sToolTip.emit("Press Enter to label all annotations.")
         else: 

--- a/taplt/ui/dialogs.py
+++ b/taplt/ui/dialogs.py
@@ -91,9 +91,10 @@ class DeleteFileMessageBox(QMessageBox):
 class DeleteShapeMessageBox(QMessageBox):
     def __init__(self, label: str, *args):
         super().__init__(*args)
+        display_label = label if label else "this annotation"
         self.setWindowTitle("Delete Annotation")
         self.setIcon(QMessageBox.Icon.Question)
-        self.setText("You are about to delete {}.\nContinue?".format(label))
+        self.setText("You are about to delete {}.\nContinue?".format(display_label))
         self.setStandardButtons(QMessageBox.StandardButton.Ok | QMessageBox.StandardButton.Cancel)
 
 

--- a/taplt/ui/file_display.py
+++ b/taplt/ui/file_display.py
@@ -23,6 +23,7 @@ class CenterDisplayWidget(QWidget):
     modalitySwitched = Signal(str)
     sZoomChanged = Signal(float)
     sEnterPressed = Signal()
+    sEscapePressed = Signal()
 
     CREATE, EDIT = 0, 1
 
@@ -70,6 +71,9 @@ class CenterDisplayWidget(QWidget):
 
         self.slide_viewer.sZoomChanged.connect(self.sZoomChanged)
         self.slide_viewer.sViewChanged.connect(self.annotations.update_shape_positions)
+
+        self.image_viewer.sEscapePressed.connect(self.annotations.cancel_drawing)
+        self.slide_viewer.sEscapePressed.connect(self.annotations.cancel_drawing)
 
     
     def on_enter_pressed(self):

--- a/taplt/ui/shape.py
+++ b/taplt/ui/shape.py
@@ -166,7 +166,6 @@ class Shape(QGraphicsObject):
                             np.array((0, 0)),
                             (self.image_size.width(), self.image_size.height()))
         return QPointF(scene_pos[0], scene_pos[1])
-    
 
     @Slot(QGraphicsSceneMouseEvent)
     def mousePressEvent(self, event: QGraphicsSceneMouseEvent):
@@ -208,12 +207,17 @@ class Shape(QGraphicsObject):
             else:
                 event.ignore()
         elif event.button() == Qt.MouseButton.RightButton:
-            if self.shape_type == "polygon" and self.mode == Shape.ShapeMode.CREATE and len(self.vertices.vertices) > 1:
+            if self.shape_type == "polygon":
+                can_finish = (self.mode == Shape.ShapeMode.CREATE and len(self.vertices.vertices) > 1)
+            else:
+                can_finish = len(self.vertices.vertices) > 0
+            if can_finish:
                 self.ungrabMouse()
                 self.is_closed_path = True
                 self.set_mode(Shape.ShapeMode.FIXED)
                 self.drawingDone.emit()
                 event.accept()
+                return
 
 
     def mouseDoubleClickEvent(self, event: QGraphicsSceneMouseEvent):

--- a/taplt/ui/shape.py
+++ b/taplt/ui/shape.py
@@ -166,18 +166,7 @@ class Shape(QGraphicsObject):
                             np.array((0, 0)),
                             (self.image_size.width(), self.image_size.height()))
         return QPointF(scene_pos[0], scene_pos[1])
-
-    def contextMenuEvent(self, event: QGraphicsSceneContextMenuEvent) -> None:
-        pos = event.screenPos()
-        menu = QMenu()
-
-        action = QAction("Delete")
-        action.triggered.connect(self.deleted.emit)
-        menu.addAction(action)
-
-        self.setSelected(True)
-        self.selected.emit()
-        menu.exec(pos)
+    
 
     @Slot(QGraphicsSceneMouseEvent)
     def mousePressEvent(self, event: QGraphicsSceneMouseEvent):

--- a/taplt/ui/shape.py
+++ b/taplt/ui/shape.py
@@ -93,6 +93,8 @@ class Shape(QGraphicsObject):
         self.init_shape()
         self.scene_size: Tuple[float, float] = (1e7, 1e7)
         self.set_mode(mode)
+        self.finished_by_right_click = False
+
 
     def set_mode(self, mode: Union[ShapeMode, int]):
         self.mode = mode
@@ -166,6 +168,27 @@ class Shape(QGraphicsObject):
                             np.array((0, 0)),
                             (self.image_size.width(), self.image_size.height()))
         return QPointF(scene_pos[0], scene_pos[1])
+    
+    def contextMenuEvent(self, event: QGraphicsSceneContextMenuEvent) -> None:\
+
+        if self.finished_by_right_click:
+            self.finished_by_right_click = False
+            event.accept()
+            return
+
+        if self.mode == Shape.ShapeMode.CREATE:
+            event.ignore()
+            return
+        pos = event.screenPos()
+        menu = QMenu()
+
+        action = QAction("Delete")
+        action.triggered.connect(self.deleted.emit)
+        menu.addAction(action)
+
+        self.setSelected(True)
+        self.selected.emit()
+        menu.exec(pos)
 
     @Slot(QGraphicsSceneMouseEvent)
     def mousePressEvent(self, event: QGraphicsSceneMouseEvent):
@@ -210,8 +233,9 @@ class Shape(QGraphicsObject):
             if self.shape_type == "polygon":
                 can_finish = (self.mode == Shape.ShapeMode.CREATE and len(self.vertices.vertices) > 1)
             else:
-                can_finish = len(self.vertices.vertices) > 0
+                can_finish = (self.mode == Shape.ShapeMode.CREATE and len(self.vertices.vertices) > 0)
             if can_finish:
+                self.finished_by_right_click = True
                 self.ungrabMouse()
                 self.is_closed_path = True
                 self.set_mode(Shape.ShapeMode.FIXED)

--- a/test/shape_test.py
+++ b/test/shape_test.py
@@ -61,8 +61,10 @@ def test_forward_first_click():
     annotation_group.set_type(Shape.ShapeType.POINT)
     annotation_group.create_shape(event)
 
-    assert annotation_group.temp_shape is not None
-    assert len(annotation_group.temp_shape.vertices.vertices) == 1
+    point_shape = annotation_group.annotations[0]
+
+    assert annotation_group.temp_shape is None
+    assert len(point_shape.vertices.vertices) == 1
 
     annotation_group.set_type(Shape.ShapeType.POLYGON)
     annotation_group.create_shape(event)

--- a/test/shape_test.py
+++ b/test/shape_test.py
@@ -147,3 +147,17 @@ def test_redo():
 
     assert shape.isVisible()
     assert shape in group.pending_shapes
+
+def test_cancel_drawing():
+    scene = QGraphicsScene()
+    annotation_group = AnnotationGroup()
+    scene.addItem(annotation_group)
+
+    annotation_group.set_type(Shape.ShapeType.POLYGON)
+    annotation_group.create_shape()
+
+    assert annotation_group.temp_shape is not None
+    assert len(annotation_group.annotations) == 1
+    annotation_group.cancel_drawing()
+    assert annotation_group.temp_shape is None
+    assert len(annotation_group.annotations) == 0


### PR DESCRIPTION
resolves #88 
### Changes: 

**image/slide_viewer and file_display.py**
- Pressing Esc consistently cancels an annotation that is currently being drawn 

**annotation_group.py:**
- `cancel_drawing()` is used to abort the annotation that is currently bein drawn and cleans up the scene, `annotations` and `pending_shapes`
- updated `remove_shapes()` to use `cancel_drawing()` when the shape being removed is still being drawn, instead of treating it as a finished annotation
- resets `temp_shape` to None in `set_drawing_to_false()` after an annotation has finished, which prevents finished annotations from being treated as the active drawing and fixes incorrect deletion and cancellation behavior. 

**shape.py:**
- made it possible for all other shape types to be finished via rightclick too
- handle `ungrabMouse()` during drawing to prevent freezes when repeatedly right clicking
- the rightclick "Delete" context menu is suppressed while a shape is still being drawn, since right click is used to finish the shape
- added `finished_by_right_click` to prevent the delete context menu from appearing immediately after a shape was just finished via right click 

**dialogs.py**:
- prevents the delete confirmation dialog from displaying "delete None" for annotations that do not have a label yet

### Testing:
- cancel annotations during drawing with **Esc** button -> all the tools should remain responsive and you should be able to draw new shapes
- the behavior of deleting finished annotations should function as it did before 


