### PR TITLE
add darkmode for sidebar and ruler

### DIFF
--- a/taplt/ui/collapsible_box.py
+++ b/taplt/ui/collapsible_box.py
@@ -1,5 +1,6 @@
 from PySide6.QtWidgets import QWidget, QVBoxLayout, QToolButton, QSizePolicy
 from PySide6.QtCore import Qt
+from taplt.utils.stylesheets import current_theme
 
 
 class CollapsibleBox(QWidget):
@@ -14,15 +15,7 @@ class CollapsibleBox(QWidget):
         self.toggle_button.setChecked(not start_collapsed)
         self.toggle_button.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextBesideIcon)
         self.toggle_button.setArrowType(Qt.ArrowType.DownArrow if not start_collapsed else Qt.ArrowType.RightArrow)
-        self.toggle_button.setStyleSheet("""
-            QToolButton {
-                border: none;
-                background-color: rgb(186, 189, 182);
-                font-weight: bold;
-                padding: 4px;
-                text-align: left;
-            }
-        """)
+        self._apply_header_style()
         self.toggle_button.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
         self.toggle_button.clicked.connect(self._on_toggle)
 
@@ -37,6 +30,23 @@ class CollapsibleBox(QWidget):
         layout.setSpacing(0)
         layout.addWidget(self.toggle_button)
         layout.addWidget(self.content_area)
+
+    def _apply_header_style(self):
+        c = current_theme()
+        self.toggle_button.setStyleSheet(f"""
+            QToolButton {{
+                border: none;
+                background-color: {c['bg_header']};
+                color: {c['text']};
+                font-weight: bold;
+                padding: 4px;
+                text-align: left;
+            }}
+        """)
+
+    def refresh_theme(self):
+        """re-applies the theme-dependent header stylesheet after a dark-mode toggle"""
+        self._apply_header_style()
 
     def setContentWidget(self, widget: QWidget):
         """Places the given widget inside the collapsible content area."""

--- a/taplt/ui/file_display.py
+++ b/taplt/ui/file_display.py
@@ -30,6 +30,9 @@ class CenterDisplayWidget(QWidget):
     def __init__(self, *args):
         super(CenterDisplayWidget, self).__init__(*args)
 
+        self.parent_window = None
+
+
         # main components of the display
         self.scene = QGraphicsScene()
         self.image_viewer = ImageViewer(self.scene)

--- a/taplt/ui/main_window.py
+++ b/taplt/ui/main_window.py
@@ -77,8 +77,10 @@ class LabelingMainWindow(QMainWindow):
 
         self.welcome_screen = WelcomeScreen()
         self.file_display = CenterDisplayWidget()
+        self.file_display.parent_window = self
         self.file_display.sZoomChanged.connect(self.update_zoom_label)
 
+    
         # zoom label on top right side
         self.zoom_label = QLabel("100%", self.file_display)
         self.zoom_label.setStyleSheet(OVERLAY_LABEL_STYLESHEET)
@@ -299,6 +301,11 @@ class LabelingMainWindow(QMainWindow):
         self.file_list.refresh_theme()
         self.toolBar.refresh_theme()
         self.polygons.refresh_theme()
+        self.file_display.top_ruler.refresh_theme()
+        self.file_display.left_ruler.refresh_theme()
+        self.labels_section.refresh_theme()
+        self.polygons_section.refresh_theme()
+        self.file_list_section.refresh_theme()
 
     def change_detected(self, change: int):
         """appends the detected change to the changes list"""

--- a/taplt/ui/ruler.py
+++ b/taplt/ui/ruler.py
@@ -7,7 +7,7 @@ from PySide6.QtWidgets import QWidget
 from PySide6.QtGui import QFont, QPainter, QColor
 from PySide6.QtCore import Qt
 
-from taplt.utils.stylesheets import FONT_SMALL
+from taplt.utils.stylesheets import FONT_SMALL, current_theme
 
 
 NICE_INTERVALS = [1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000, 20000, 50000, 100000]
@@ -192,14 +192,15 @@ class RulerWidget(QWidget):
 
     def paintEvent(self, event):
         painter = QPainter(self)
+        c = current_theme()
 
         pen = painter.pen()
-        pen.setColor(QColor(95, 95, 95))
+        pen.setColor(QColor(c["ruler_line"]))
         pen.setWidth(1)
         painter.setPen(pen)
 
         # Draw the ruler background
-        painter.fillRect(self.rect(), QColor(240, 240, 240))
+        painter.fillRect(self.rect(), QColor(c["ruler_bg"]))
 
         # Draw the ruler ticks and labels based on orientation
         if self.orientation == self.HORIZONTAL:
@@ -284,3 +285,7 @@ class RulerWidget(QWidget):
 
         # Draw the baseline at the bottom
         painter.drawLine(self.width() - 1, 0, self.width() - 1, self.height())
+
+    def refresh_theme(self):
+        """triggers a repaint so the ruler picks up the new theme colors"""
+        self.update()

--- a/taplt/ui/ruler.py
+++ b/taplt/ui/ruler.py
@@ -122,6 +122,17 @@ def read_slide_metadata(slide) -> dict:
     avg_mpp = (mpp_x + mpp_y) / 2.0
     return create_physical_context(avg_mpp) 
 
+def parse_color(value: str) -> QColor:
+    """Converts theme color strings into valid QColor objects."""
+    if value.startswith("rgb"):
+        try:
+            r, g, b = map(int, value[4:-1].split(","))
+            return QColor(r, g, b)
+        except Exception:
+            return QColor()  # invalid
+    return QColor(value)
+
+
 
 class RulerWidget(QWidget):
 
@@ -191,16 +202,21 @@ class RulerWidget(QWidget):
         return format_measurement_value(value, unit)
 
     def paintEvent(self, event):
+        
         painter = QPainter(self)
         c = current_theme()
 
+        
+        bg_color = parse_color(c["ruler_bg"])
+        line_color = parse_color(c["ruler_line"])
+
         pen = painter.pen()
-        pen.setColor(QColor(c["ruler_line"]))
+        pen.setColor(line_color)
         pen.setWidth(1)
         painter.setPen(pen)
 
         # Draw the ruler background
-        painter.fillRect(self.rect(), QColor(c["ruler_bg"]))
+        painter.fillRect(self.rect(), bg_color)
 
         # Draw the ruler ticks and labels based on orientation
         if self.orientation == self.HORIZONTAL:

--- a/taplt/utils/stylesheets.py
+++ b/taplt/utils/stylesheets.py
@@ -9,10 +9,12 @@ FONT_LARGE = 13
 THEMES = {
     "light": dict(bg="rgb(240,240,240)", bg_header="rgb(186,189,182)",
                   bg_hover="rgb(220,220,220)", bg_selected="rgb(180,200,230)",
-                  text="black", text_selected="black", border="lightgray"),
+                  text="black", text_selected="black", border="lightgray", 
+                  ruler_bg="rgb(240,240,240)", ruler_line="rgb(95,95,95)"),
     "dark": dict(bg="rgb(45,45,45)", bg_header="rgb(60,60,60)",
                  bg_hover="rgb(70,70,70)", bg_selected="rgb(70,100,140)",
-                 text="white", text_selected="black", border="rgb(80,80,80)"),
+                 text="white", text_selected="black", border="rgb(80,80,80)",
+                 ruler_bg="rgb(45,45,45)", ruler_line="rgb(200,200,200)"),
 }
 
 ACTIVE_THEME = "light"  


### PR DESCRIPTION
resolves #90 
### Sidebar
Die Styles der aufklappbaren Collapsible Boxes in der sidebar waren noch hardgecodet -> haben sich beim Umstellen auf darkmode nicht angepasst. 
#### Fix:
Statt festem stylesheet die Farbe auf `bg_header` umgestellt und in `main_window.py` die einzelnen Elemente der refresh theme Methode hinzugefügt, damit sie geupdated werden.
#### Test:
System auf darkmode stellen

### Lineal
Styles waren hardgecodet
#### Fix:
- im Theme Dictionary neue Farben für das Lineal hinzugefügt
- diese dann statt festem Stylesheet aufgerufen
- in `main_window.py` der refresh theme Methode hinzugefügt
--> momentan noch ein Problem, weil das Lineal in `file_display.py` instanziert wird? 
#####Fix dafür: 
- Verbindung von `main_window.py` zu `file_display.py`
über `self.file_display = CenterDisplayWidget()
self.file_display.parent_window = self
`
- Parser für die Theme-Farben in `ruler.py` (weil die QCOlor nicht verarbeitet werden konnte -> Lineal war nicht sichtbar) + Anpassung entsprechend in `paintEvent`

=> der Darkmode sollte jetzt vollständig funktionieren

### Test
systemseitig Darkmode einstellen und dann das Programm öffnen