### PR TITLE
fix toolbar test

### DIFF
--- a/test/manual_ui_testing.py
+++ b/test/manual_ui_testing.py
@@ -11,7 +11,7 @@ from taplt.ui.shape import Shape
 from taplt.ui.toolbar import Toolbar
 from taplt.src.main_logic import MainLogic
 from taplt.utils.qt import colormap_rgb
-from taplt.utils.stylesheets import TAB_STYLESHEET, BASE_FONT_SIZE
+from taplt.utils.stylesheets import get_tab_stylesheet, BASE_FONT_SIZE
 from taplt.ui.welcome_screen import WelcomeScreen
 
 COLORS, _ = colormap_rgb(25)
@@ -153,29 +153,30 @@ def test_tab():
     w2.layout().addWidget(QLabel("Widget 2"))
     tab.addTab(w1, 'First')
     tab.addTab(w2, 'Second')
-    tab.setStyleSheet(TAB_STYLESHEET.format(tab_size=BASE_FONT_SIZE))
+    tab.setStyleSheet(get_tab_stylesheet(BASE_FONT_SIZE))
     tab.show()
     app.exec()
 
 
 def test_toolbar():
     window = QMainWindow()
-    window.resize(400, 800)
+    window.setWindowTitle("Toolbar manual test")
+    window.resize(600, 700)
 
     center = QWidget()
-    center.setLayout(QVBoxLayout())
+    center.setStyleSheet("background-color: white;")
     window.setCentralWidget(center)
 
-    tb = Toolbar(center)
+    action_source = LabelingMainWindow()
+    toolbar = Toolbar(center)
+    toolbar.init_actions("image", action_source.define_img_actions())
+    toolbar.switch_modality("image")
+    toolbar.toggle_button.setChecked(True)
+    toolbar._toggle_visibility(True)
+    toolbar.move(12, 80)
 
-    mw = LabelingMainWindow()
-    tb.init_actions("image", mw.define_img_actions())
-    tb.switch_modality("image")
-
-    tb.move(10, 10)
-    tb.show()
-    
     window.show()
+    toolbar.raise_()
     app.exec()
 
 def test_welcome_screen():
@@ -203,9 +204,9 @@ if __name__ == "__main__":
     # test_label_list()
     # test_dialog_delete_class()
     # test_file_viewing_widget()
-    test_tree_widget()
+    # test_tree_widget()
     # test_dialog_new_label()
     # test_image_display()
     test_toolbar()
     # test_main_window()
-    test_welcome_screen()
+    # test_welcome_screen()


### PR DESCRIPTION
Resolves #45 

Die Toolbar wird im manuellen UI-Test jetzt korrekt dargestellt.

### Änderungen in `manual_ui_testing.py`

- Veraltete Stylesheet-Verwendung im manuellen Test angepasst
- Toolbar-Test an die aktuelle Toolbar-Implementierung angepasst
- Test läuft in einem separaten Fenster mit weißem Hintergrund
- Toolbar nutzt die aktuellen Image-Buttons
- Toolbar kann verschoben und ein- bzw. ausgeklappt werden

### Test

`venv/bin/python test/manual_ui_testing.py`

Die Toolbar sollte vollständig sichtbar sein, sich über den Toggle-Button verschieben lassen und beim Klicken ein- bzw. ausgeklappt werden.