### PR TITLE
use xcb backend on Linux

### DIFF
--- a/taplt/__main__.py
+++ b/taplt/__main__.py
@@ -1,5 +1,11 @@
 import argparse
+import os
 import sys
+
+# Qt's Wayland backend ignores move() for top-level windows, which can place
+# modal dialogs behind the main window. Use X11 via XWayland on Linux.
+if sys.platform.startswith("linux"):
+    os.environ.setdefault("QT_QPA_PLATFORM", "xcb")
 
 from pathlib import Path
 from PySide6.QtWidgets import QApplication


### PR DESCRIPTION
Resolves #102 

- Dialoge erscheinen wieder korrekt vor dem Hauptfenster
- Werkzeuge reagieren normal, keine blockierten Eingaben
- Kein Flackern mehr
- Fensterpositionierung (move()) funktioniert unter Linux wie unter macOS/X11

### Änderungen in `taplt/__main__`

Vor den PySide6‑Imports wird das X11‑Backend erzwungen: 
```
if sys.platform.startswith("linux"):
    os.environ.setdefault("QT_QPA_PLATFORM", "xcb")
```


